### PR TITLE
Automatically resolve tasks within flows

### DIFF
--- a/examples/task_dag.py
+++ b/examples/task_dag.py
@@ -1,0 +1,28 @@
+from controlflow import Task, flow
+
+
+@flow
+def book_ideas():
+    genre = Task("pick a genre", str)
+    ideas = Task(
+        "generate three short ideas for a book",
+        list[str],
+        context=dict(genre=genre),
+    )
+    abstract = Task(
+        "pick one idea and write an abstract",
+        str,
+        context=dict(ideas=ideas, genre=genre),
+    )
+    title = Task(
+        "pick a title",
+        str,
+        context=dict(abstract=abstract),
+    )
+
+    return dict(genre=genre, ideas=ideas, abstract=abstract, title=title)
+
+
+if __name__ == "__main__":
+    result = book_ideas()
+    print(result)

--- a/src/controlflow/__init__.py
+++ b/src/controlflow/__init__.py
@@ -1,10 +1,11 @@
 from .settings import settings
 
-from .core.flow import Flow, reset_global_flow as _reset_global_flow, flow
-from .core.task import Task, task
+from .core.flow import Flow, reset_global_flow as _reset_global_flow
+from .core.task import Task
 from .core.agent import Agent
 from .core.controller.controller import Controller
 from .instructions import instructions
+from .decorators import flow, task
 
 Flow.model_rebuild()
 Task.model_rebuild()

--- a/src/controlflow/core/flow.py
+++ b/src/controlflow/core/flow.py
@@ -1,9 +1,6 @@
-import functools
-import inspect
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Union
 
-import prefect
 from marvin.beta.assistants import Thread
 from openai.types.beta.threads import Message
 from pydantic import Field, field_validator
@@ -11,7 +8,6 @@ from pydantic import Field, field_validator
 import controlflow
 from controlflow.utilities.context import ctx
 from controlflow.utilities.logging import get_logger
-from controlflow.utilities.marvin import patch_marvin
 from controlflow.utilities.types import ControlFlowModel, ToolType
 
 if TYPE_CHECKING:
@@ -95,59 +91,3 @@ def get_flow_messages(limit: int = None) -> list[Message]:
     """
     flow = get_flow()
     return flow.thread.get_messages(limit=limit)
-
-
-def flow(
-    fn=None,
-    *,
-    thread: Thread = None,
-    instructions: str = None,
-    tools: list[ToolType] = None,
-    agents: list["Agent"] = None,
-):
-    """
-    A decorator that runs a function as a Flow
-    """
-
-    if fn is None:
-        return functools.partial(
-            flow,
-            thread=thread,
-            tools=tools,
-            agents=agents,
-        )
-
-    sig = inspect.signature(fn)
-
-    @functools.wraps(fn)
-    def wrapper(
-        *args,
-        flow_kwargs: dict = None,
-        **kwargs,
-    ):
-        # first process callargs
-        bound = sig.bind(*args, **kwargs)
-        bound.apply_defaults()
-
-        flow_kwargs = flow_kwargs or {}
-
-        if thread is not None:
-            flow_kwargs.setdefault("thread", thread)
-        if tools is not None:
-            flow_kwargs.setdefault("tools", tools)
-        if agents is not None:
-            flow_kwargs.setdefault("agents", agents)
-
-        p_fn = prefect.flow(fn)
-
-        flow_obj = Flow(**flow_kwargs, context=bound.arguments)
-
-        logger.info(
-            f'Executing AI flow "{fn.__name__}" on thread "{flow_obj.thread.id}"'
-        )
-
-        with ctx(flow=flow_obj), patch_marvin():
-            with controlflow.instructions(instructions):
-                return p_fn(*args, **kwargs)
-
-    return wrapper

--- a/src/controlflow/decorators.py
+++ b/src/controlflow/decorators.py
@@ -1,0 +1,184 @@
+import functools
+import inspect
+
+import prefect
+from marvin.beta.assistants import Thread
+
+import controlflow
+from controlflow.core.agent import Agent
+from controlflow.core.flow import Flow
+from controlflow.core.task import Task
+from controlflow.utilities.logging import get_logger
+from controlflow.utilities.marvin import patch_marvin
+from controlflow.utilities.tasks import resolve_tasks
+from controlflow.utilities.types import ToolType
+
+logger = get_logger(__name__)
+
+
+def flow(
+    fn=None,
+    *,
+    thread: Thread = None,
+    instructions: str = None,
+    tools: list[ToolType] = None,
+    agents: list["Agent"] = None,
+    resolve_results: bool = None,
+):
+    """
+    A decorator that wraps a function as a ControlFlow flow.
+
+    When the function is called, a new flow is created and any tasks created
+    within the function will be run as part of that flow. When the function
+    returns, all tasks created in the flow will be run to completion (if they
+    were not already completed) and their results will be returned. Any tasks
+    that are returned from the function will be replaced with their resolved
+    result.
+
+    Args:
+        fn (callable, optional): The function to be wrapped as a flow. If not provided,
+            the decorator will act as a partial function and return a new flow decorator.
+        thread (Thread, optional): The thread to execute the flow on. Defaults to None.
+        instructions (str, optional): Instructions for the flow. Defaults to None.
+        tools (list[ToolType], optional): List of tools to be used in the flow. Defaults to None.
+        agents (list[Agent], optional): List of agents to be used in the flow. Defaults to None.
+        resolve_results (bool, optional): Whether to resolve the results of tasks. Defaults to True.
+
+    Returns:
+        callable: The wrapped function or a new flow decorator if `fn` is not provided.
+    """
+    ...
+
+    if fn is None:
+        return functools.partial(
+            flow,
+            thread=thread,
+            instructions=instructions,
+            tools=tools,
+            agents=agents,
+            resolve_results=resolve_results,
+        )
+
+    if resolve_results is None:
+        resolve_results = True
+    sig = inspect.signature(fn)
+
+    @functools.wraps(fn)
+    def wrapper(
+        *args,
+        flow_kwargs: dict = None,
+        **kwargs,
+    ):
+        # first process callargs
+        bound = sig.bind(*args, **kwargs)
+        bound.apply_defaults()
+
+        flow_kwargs = flow_kwargs or {}
+
+        if thread is not None:
+            flow_kwargs.setdefault("thread", thread)
+        if tools is not None:
+            flow_kwargs.setdefault("tools", tools)
+        if agents is not None:
+            flow_kwargs.setdefault("agents", agents)
+
+        p_fn = prefect.flow(fn)
+
+        flow_obj = Flow(**flow_kwargs, context=bound.arguments)
+
+        logger.info(
+            f'Executing AI flow "{fn.__name__}" on thread "{flow_obj.thread.id}"'
+        )
+
+        with flow_obj, patch_marvin():
+            with Task(
+                fn.__name__,
+                instructions="Complete all subtasks of this task.",
+                is_auto_completed_by_subtasks=True,
+                context=bound.arguments,
+            ) as parent_task:
+                with controlflow.instructions(instructions):
+                    result = p_fn(*args, **kwargs)
+
+                    # ensure all subtasks are completed
+                    parent_task.run()
+
+                    if resolve_results:
+                        # resolve any returned tasks; this will raise on failure
+                        result = resolve_tasks(result)
+
+            return result
+
+    return wrapper
+
+
+def task(
+    fn=None,
+    *,
+    objective: str = None,
+    instructions: str = None,
+    agents: list["Agent"] = None,
+    tools: list[ToolType] = None,
+    user_access: bool = None,
+):
+    """
+    A decorator that turns a Python function into a Task. The Task objective is
+    set to the function name, and the instructions are set to the function
+    docstring. When the function is called, the arguments are provided to the
+    task as context, and the task is run to completion. If successful, the task
+    result is returned; if failed, an error is raised.
+
+    Args:
+        fn (callable, optional): The function to be wrapped as a task. If not provided,
+            the decorator will act as a partial function and return a new task decorator.
+        objective (str, optional): The objective of the task. Defaults to None, in which
+            case the function name is used as the objective.
+        instructions (str, optional): Instructions for the task. Defaults to None, in which
+            case the function docstring is used as the instructions.
+        agents (list[Agent], optional): List of agents to be used in the task. Defaults to None.
+        tools (list[ToolType], optional): List of tools to be used in the task. Defaults to None.
+        user_access (bool, optional): Whether the task requires user access. Defaults to None,
+            in which case it is set to False.
+
+    Returns:
+        callable: The wrapped function or a new task decorator if `fn` is not provided.
+    """
+
+    if fn is None:
+        return functools.partial(
+            task,
+            objective=objective,
+            instructions=instructions,
+            agents=agents,
+            tools=tools,
+            user_access=user_access,
+        )
+
+    sig = inspect.signature(fn)
+
+    if objective is None:
+        objective = fn.__name__
+
+    if instructions is None:
+        instructions = fn.__doc__
+
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        # first process callargs
+        bound = sig.bind(*args, **kwargs)
+        bound.apply_defaults()
+
+        task = Task(
+            objective=objective,
+            instructions=instructions,
+            agents=agents,
+            context=bound.arguments,
+            result_type=fn.__annotations__.get("return"),
+            user_access=user_access or False,
+            tools=tools or [],
+        )
+
+        task.run()
+        return task.result
+
+    return wrapper

--- a/src/controlflow/utilities/tasks.py
+++ b/src/controlflow/utilities/tasks.py
@@ -1,0 +1,89 @@
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    TypeVar,
+)
+
+from controlflow.utilities.logging import get_logger
+
+if TYPE_CHECKING:
+    from controlflow.core.task import Task
+
+T = TypeVar("T")
+logger = get_logger(__name__)
+
+
+def visit_task_collection(
+    val: Any, visitor: Callable, recursion_limit: int = 10, _counter: int = 0
+) -> list["Task"]:
+    """
+    Recursively visits a task collection and applies a visitor function to each task.
+
+    Args:
+        val (Any): The task collection to visit.
+        visitor (Callable): The visitor function to apply to each task.
+        recursion_limit (int, optional): The maximum recursion limit. Defaults to 3.
+        _counter (int, optional): Internal counter to track recursion depth. Defaults to 0.
+
+    Returns:
+        list["Task"]: The modified task collection after applying the visitor function.
+
+    """
+    from controlflow.core.task import Task
+
+    if _counter >= recursion_limit:
+        return val
+
+    if isinstance(val, dict):
+        result = {}
+        for key, value in list(val.items()):
+            result[key] = visit_task_collection(
+                value,
+                visitor=visitor,
+                recursion_limit=recursion_limit,
+                _counter=_counter + 1,
+            )
+        return result
+    elif isinstance(val, (list, set, tuple)):
+        result = []
+        for item in val:
+            result.append(
+                visit_task_collection(
+                    item,
+                    visitor=visitor,
+                    recursion_limit=recursion_limit,
+                    _counter=_counter + 1,
+                )
+            )
+        return type(val)(result)
+    elif isinstance(val, Task):
+        return visitor(val)
+
+    return val
+
+
+def collect_tasks(val: T) -> list["Task"]:
+    """
+    Given a collection of tasks, returns a list of all tasks in the collection.
+    """
+
+    tasks = []
+
+    def visit_task(task: "Task"):
+        tasks.append(task)
+        return task
+
+    visit_task_collection(val, visit_task)
+    return tasks
+
+
+def resolve_tasks(val: T) -> T:
+    """
+    Given a collection of tasks, runs them to completion and returns the results.
+    """
+
+    def visit_task(task: "Task"):
+        return task.run()
+
+    return visit_task_collection(val, visit_task)


### PR DESCRIPTION
This PR moves flow/task decorators to their own module, and adds functionality to automatically run and resolve and tasks created/returned by a flow function. 

```python
from controlflow import Task, flow


@flow
def book_ideas():
    genre = Task("pick a genre", str)
    ideas = Task(
        "generate three short ideas for a book",
        list[str],
        context=dict(genre=genre),
    )
    abstract = Task(
        "pick one idea and write an abstract",
        str,
        context=dict(ideas=ideas, genre=genre),
    )
    title = Task(
        "pick a title",
        str,
        context=dict(abstract=abstract),
    )

    return dict(genre=genre, ideas=ideas, abstract=abstract, title=title)


if __name__ == "__main__":
    result = book_ideas()
    print(result)
```