### PR TITLE
Remove flow task; add threadmessage construct

### DIFF
--- a/src/controlflow/__init__.py
+++ b/src/controlflow/__init__.py
@@ -1,6 +1,6 @@
 from .settings import settings
 
-from .core.flow import Flow, reset_global_flow as _reset_global_flow
+from .core.flow import Flow, reset_global_flow
 from .core.task import Task
 from .core.agent import Agent
 from .core.controller.controller import Controller
@@ -11,4 +11,4 @@ Flow.model_rebuild()
 Task.model_rebuild()
 Agent.model_rebuild()
 
-_reset_global_flow()
+reset_global_flow()

--- a/src/controlflow/core/controller/instruction_template.py
+++ b/src/controlflow/core/controller/instruction_template.py
@@ -98,18 +98,28 @@ class TasksTemplate(Template):
         
         You can only mark a task successful when all of its dependencies and
         subtasks have been completed. Subtasks may be marked as skipped without
-        providing a result. All else equal, prioritize older tasks over newer ones.
+        providing a result. All else equal, prioritize older tasks over newer
+        ones.
 
         ### Providing a result
         
-        Tasks may optionally request a typed result. Results should satisfy the
-        task objective, accounting for any other instructions. If a task does
-        not require a result, you must still complete the objective by posting
-        messages or using other tools before marking the task as complete.
+        Tasks may require a typed result (the `result_type`). Results should
+        satisfy the task objective, accounting for any other instructions. If a
+        task does not require a result (`result_type=None`), you must still
+        complete its stated objective by posting messages or using other tools
+        before marking the task as complete.
         
-        Try not to write out long results in messages that other agents can
-        read, and then repeating the entire result when marking the task as
-        complete. Other agents can see your task results when it is their turn.
+        #### Re-using a message
+        
+        You can reuse the contents of any message as a task's result by
+        providing a special `ThreadMessage` object when marking a task
+        successful. Only do this if the thread message can be converted into the
+        task's result_type. Indicate the number of messages ago that the message
+        was posted (defaults to 1). Also provide any characters to strip from the
+        start or end of the message, to make sure that the result doesn't reveal
+        any internal details (for example, always remove your name prefix and
+        irrelevant comments from the beginning or end of the response such as
+        "I'll mark the task complete now.").
         
         """
     tasks: list[Task]

--- a/src/controlflow/core/flow.py
+++ b/src/controlflow/core/flow.py
@@ -65,16 +65,13 @@ GLOBAL_FLOW = None
 def get_flow() -> Flow:
     """
     Loads the flow from the context.
-
-    Will error if no flow is found in the context, unless the global flow is
-    enabled in settings
     """
     flow: Union[Flow, None] = ctx.get("flow")
     if not flow:
         if controlflow.settings.enable_global_flow:
             return GLOBAL_FLOW
         else:
-            raise ValueError("No flow found in context.")
+            raise ValueError("No flow found in context and global flow is disabled.")
     return flow
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+from controlflow import reset_global_flow
 from controlflow.settings import temporary_settings
 from prefect.testing.utilities import prefect_test_harness
 
@@ -7,8 +8,12 @@ from .fixtures import *
 
 @pytest.fixture(autouse=True, scope="session")
 def temp_controlflow_settings():
-    with temporary_settings(enable_global_flow=False, max_task_iterations=3):
-        yield
+    with temporary_settings(max_task_iterations=3):
+        try:
+            yield
+        finally:
+            # reset the global flow after each test
+            reset_global_flow()
 
 
 @pytest.fixture(autouse=True, scope="session")


### PR DESCRIPTION
The @flow decorator was using a "parent task" to automatically track all tasks added in the flow, but this confused the agents, who viewed that task as part of their mandate (and created complexity around how to decide if it was successful, failed, skipped, etc). 

Instead, we replace the parent task with the existing task-tracking mechanism of the flow, and spawn a Controller to run all registered tasks to completion before returning from the flow decorator.

This also includes an important enhancement: the ThreadMessage object. Agents often post messages, then repeat the entire message as a Task result. By passing a special ThreadMessage object, they can indicate that the task result should be loaded from a previous response, saving time and tokens.