### PR TITLE
Fix issue with not rendering all messages

### DIFF
--- a/src/controlflow/llm/formatting.py
+++ b/src/controlflow/llm/formatting.py
@@ -1,6 +1,6 @@
 import datetime
 import inspect
-from typing import Optional
+from typing import Optional, Union
 
 from rich import box
 from rich.console import Group
@@ -29,15 +29,22 @@ def format_timestamp(timestamp: datetime.datetime) -> str:
     return timestamp.strftime("%l:%M:%S %p")
 
 
-def format_message(message: MessageType, width: Optional[int] = None) -> Panel:
+def format_message(
+    message: MessageType, width: Optional[int] = None
+) -> Union[Panel, Group]:
+    panels = []
     if isinstance(message, ToolMessage):
         return format_tool_message(message, width=width)
-    elif isinstance(message, AIMessage) and (
-        message.tool_calls or message.invalid_tool_calls
-    ):
-        return format_ai_message_with_tool_calls(message, width=width)
-    else:
-        return format_text_message(message, width=width)
+    elif isinstance(message, AIMessage):
+        if message.content:
+            panels.append(format_text_message(message, width=width))
+
+        if message.tool_calls or message.invalid_tool_calls:
+            panels.append(format_ai_message_with_tool_calls(message, width=width))
+
+    if len(panels) == 1:
+        return panels[0]
+    return Group(*panels)
 
 
 def format_text_message(message: MessageType, width: Optional[int] = None) -> Panel:

--- a/src/controlflow/llm/messages.py
+++ b/src/controlflow/llm/messages.py
@@ -13,13 +13,16 @@ class MessageMixin(langchain_core.messages.BaseMessage):
     class Config:
         validate_assignment = True
 
-    # default ID value
-    id: str = v1_Field(default_factory=lambda: uuid.uuid4().hex)
-
     # add timestamp
     timestamp: datetime.datetime = v1_Field(
         default_factory=lambda: datetime.datetime.now(datetime.timezone.utc),
     )
+
+    def __init__(self, **data):
+        # for some reason the id is not set if we add a default_factory
+        if data.get("id") is None:
+            data["id"] = uuid.uuid4().hex
+        super().__init__(**data)
 
     def render(self, **kwargs) -> "MessageType":
         """


### PR DESCRIPTION
LLM messages can contain both a message and multiple tool calls, which violates an implicit assumption in the formatters that each message corresponding to a specific type of response.

This PR:
- improves completion event emission for potentially dual-role messages
- improves handling of response messages to avoid double-counting
- improves rendering of dual-role messages