### PR TITLE
Support static print when Live is running

### DIFF
--- a/src/controlflow/utilities/rich.py
+++ b/src/controlflow/utilities/rich.py
@@ -1,0 +1,3 @@
+from rich.console import Console
+
+console = Console()


### PR DESCRIPTION
Currently if one `PrintHandler` is running, any other attempts to start one fail because rich only supports one Live object at a time. This PR makes it so the 2nd+ PrintHandler just prints its content rather than liv-estreams.