### PR TITLE
Move history to the flow

### DIFF
--- a/src/controlflow/__init__.py
+++ b/src/controlflow/__init__.py
@@ -16,11 +16,11 @@ from .decorators import flow, task
 
 # --- Default history ---
 # assign to controlflow.default_history to change the default history
-from .llm.history import DEFAULT_HISTORY as default_history
+from .llm.history import DEFAULT_HISTORY as default_history, get_default_history
 
 # --- Default agent ---
 # assign to controlflow.default_agent to change the default agent
-from .core.agent.agent import DEFAULT_AGENT as default_agent
+from .core.agent.agent import DEFAULT_AGENT as default_agent, get_default_agent
 
 # --- Version ---
 try:


### PR DESCRIPTION
moves history object storage from the controller (which is not user facing) to the flow (which is). This has a few benefits:
- users can specify different history objects for different flows (previously had to set a global default for the controller to load)
- direct history manipulation becomes possible
- subflows can inherit the parent flow's history, but create a branch to avoid modifying it. This means that you can create a subflow to let agents confer privately, without polluting the parent thread, while still having full access to its information