### PR TITLE
Simplify the quickstart and make it more imperative

### DIFF
--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -86,10 +86,9 @@ Let's create three agents: a `writer`, an `editor`, and a `manager`.
 
 - The writer begins the workflow by drafting a paragraph.
 - The editor refines the draft.
-- The manager reviews the final result.
-The manager has private instructions to be strict in its assessment.
+- The manager reviews the final result and approves if its criteria is met.
 
-The `approval_task` function is run at the end of each iteration to see if the manager approves the paragraph.
+The `approval_task` function is run at the end of each iteration to see if the manager approved the paragraph.
 If not, the editing process continues until approval is granted.
 
 ```python


### PR DESCRIPTION
Preview: https://controlflow-make_the_quickstart_more_linear_and_imperative.mintlify.app/quickstart

* Simplify the explanations of key concepts in the quickstart, and cross-link to the full concept pages for people who want the more detailed explanation.
* Move the explanation of code before the code block it describes to more clearly set expectations.
* Rename section titles to be action-focused ("do the thing") instead of purely descriptive ("the thing").
* Convert paragraphs to [ventilated prose](https://writetheasciidocs.netlify.app/ventilated-prose) so that future edits are easier to review.
* Remove explicit `---` line separators since the headings introduce enough negative space on their own.
* Code styling suggestion: shorten code examples by merging back-to-back empty lines.