### PR TITLE
Make tool calls private by default

### DIFF
--- a/src/controlflow/controllers/controller.py
+++ b/src/controlflow/controllers/controller.py
@@ -10,7 +10,7 @@ from pydantic import Field, PrivateAttr, model_validator
 import controlflow
 from controlflow.agents import Agent
 from controlflow.controllers.graph import Graph
-from controlflow.controllers.messages import process_messages
+from controlflow.controllers.messages import prepare_messages
 from controlflow.flows import Flow, get_flow
 from controlflow.instructions import get_instructions
 from controlflow.llm.completions import completion, completion_async
@@ -187,7 +187,13 @@ class Controller(ControlFlowModel):
         messages = self.flow.get_messages()
 
         rules = agent.get_llm_rules()
-        messages = process_messages(messages, rules=rules, tools=tools)
+        messages = prepare_messages(
+            agent=agent,
+            system_message=system_message,
+            messages=messages,
+            rules=rules,
+            tools=tools,
+        )
 
         # setup handlers
         handlers = []
@@ -198,7 +204,7 @@ class Controller(ControlFlowModel):
         # yield the agent payload
         return dict(
             agent=agent,
-            messages=[system_message] + messages,
+            messages=messages,
             tools=as_tools(tools),
             handlers=handlers,
         )

--- a/src/controlflow/controllers/messages.py
+++ b/src/controlflow/controllers/messages.py
@@ -12,7 +12,12 @@ from controlflow.llm.rules import LLMRules
 from controlflow.llm.tools import Tool
 
 
-def system_message(content: str, rules: LLMRules) -> Union[SystemMessage, HumanMessage]:
+def create_system_message(
+    content: str, rules: LLMRules
+) -> Union[SystemMessage, HumanMessage]:
+    """
+    Creates a SystemMessage or HumanMessage with SYSTEM: prefix, depending on the rules.
+    """
     if rules.system_message_must_be_first:
         return SystemMessage(content=content)
     else:
@@ -107,7 +112,7 @@ def prepare_messages(
 
     if not rules.allow_last_message_has_ai_role_with_tools:
         if messages and tools and isinstance(messages[-1], AIMessage):
-            messages.append(system_message("Continue.", rules))
+            messages.append(create_system_message("Continue.", rules))
 
     if not rules.allow_consecutive_ai_messages:
         if messages:
@@ -116,8 +121,8 @@ def prepare_messages(
                 if isinstance(messages[i], AIMessage) and isinstance(
                     messages[i - 1], AIMessage
                 ):
-                    messages.insert(i, system_message("Continue.", rules))
-                    i += 1
+                    messages.insert(i, create_system_message("Continue.", rules))
+                i += 1
 
     messages = handle_system_messages_must_be_first(messages, rules)
     messages = handle_user_message_must_be_first_after_system(messages, rules)

--- a/src/controlflow/controllers/messages.py
+++ b/src/controlflow/controllers/messages.py
@@ -1,6 +1,13 @@
-from typing import Union
+from typing import Optional, Union
 
-from controlflow.llm.messages import AIMessage, HumanMessage, MessageType, SystemMessage
+from controlflow.agents.agent import Agent
+from controlflow.llm.messages import (
+    AIMessage,
+    HumanMessage,
+    MessageType,
+    SystemMessage,
+    ToolMessage,
+)
 from controlflow.llm.rules import LLMRules
 from controlflow.llm.tools import Tool
 
@@ -12,9 +19,7 @@ def system_message(content: str, rules: LLMRules) -> Union[SystemMessage, HumanM
         return HumanMessage(content=f"SYSTEM: {content}")
 
 
-def add_agent_info_to_messages(
-    messages: list[MessageType], llm_rules: LLMRules
-) -> list[MessageType]:
+def add_agent_info_to_messages(messages: list[MessageType]) -> list[MessageType]:
     """
     If the message is from an agent, add a system message to clarify which agent
     it is from. This helps the system follow multi-agent conversations.
@@ -22,31 +27,83 @@ def add_agent_info_to_messages(
     new_messages = []
     for msg in messages:
         if isinstance(msg, AIMessage) and msg.agent:
-            if llm_rules.system_message_must_be_first:
-                system_msg = HumanMessage(
-                    content=f'SYSTEM: The following message is from agent "{msg.agent.name}" with id {msg.agent.id}.'
-                )
-            else:
-                system_msg = SystemMessage(
-                    content=f'The following message is from agent "{msg.agent.name}" with id {msg.agent.id}.'
-                )
+            system_msg = SystemMessage(
+                content=f'The following message is from agent "{msg.agent.name}" with id {msg.agent.id}.'
+            )
             new_messages.append(system_msg)
         new_messages.append(msg)
     return new_messages
 
 
-def process_messages(
+def handle_system_messages_must_be_first(messages: list[MessageType], rules: LLMRules):
+    if rules.system_message_must_be_first:
+        new_messages = []
+        # consolidate consecutive SystemMessages into one
+        if isinstance(messages[0], SystemMessage):
+            content = [messages[0].content]
+            i = 1
+            while i < len(messages) and isinstance(messages[i], SystemMessage):
+                i += 1
+                content.append(messages[i].content)
+            new_messages.append(SystemMessage(content="\n\n".join(content)))
+
+        # replace all other SystemMessages with HumanMessages
+        for i, msg in enumerate(messages[len(new_messages) :]):
+            if isinstance(msg, SystemMessage):
+                msg = HumanMessage(content=f"SYSTEM: {msg.content}")
+            new_messages.append(msg)
+
+        return new_messages
+    else:
+        return messages
+
+
+def handle_user_message_must_be_first_after_system(
+    messages: list[MessageType], rules: LLMRules
+):
+    if rules.user_message_must_be_first_after_system:
+        if not messages:
+            messages.append(HumanMessage(content="SYSTEM: Begin."))
+
+        # else get first non-system message
+        else:
+            i = 0
+            while i < len(messages) and isinstance(messages[i], SystemMessage):
+                i += 1
+            if i == len(messages) or (
+                i < len(messages) and not isinstance(messages[i], HumanMessage)
+            ):
+                messages.insert(i, HumanMessage(content="SYSTEM: Begin."))
+    return messages
+
+
+def handle_private_tool_calls(messages: list[MessageType], agent: Agent):
+    new_messages = []
+    for msg in messages:
+        if isinstance(msg, ToolMessage):
+            if agent.id != msg.agent_id:
+                msg = ToolMessage(
+                    content=f"The result of this tool call only visible to agent {msg.agent_id}",
+                    tool_call_id=msg.tool_call_id,
+                    tool_metadata=msg.tool_metadata | {"is_private": True},
+                )
+        new_messages.append(msg)
+    return new_messages
+
+
+def prepare_messages(
+    agent: Agent,
     messages: list[MessageType],
+    system_message: Optional[SystemMessage],
     rules: LLMRules,
     tools: list[Tool],
 ):
     messages = messages.copy()
 
-    messages = add_agent_info_to_messages(messages, rules)
+    if system_message is not None:
+        messages.insert(0, system_message)
 
-    if rules.always_start_with_user_message:
-        if not messages or not isinstance(messages[0], HumanMessage):
-            messages.insert(0, HumanMessage(content="SYSTEM: Begin."))
+    messages = add_agent_info_to_messages(messages)
 
     if not rules.allow_last_message_has_ai_role_with_tools:
         if messages and tools and isinstance(messages[-1], AIMessage):
@@ -61,5 +118,9 @@ def process_messages(
                 ):
                     messages.insert(i, system_message("Continue.", rules))
                     i += 1
+
+    messages = handle_system_messages_must_be_first(messages, rules)
+    messages = handle_user_message_must_be_first_after_system(messages, rules)
+    messages = handle_private_tool_calls(messages, agent)
 
     return messages

--- a/src/controlflow/llm/formatting.py
+++ b/src/controlflow/llm/formatting.py
@@ -127,7 +127,7 @@ def format_tool_message(message: ToolMessage, width: Optional[int] = None) -> Pa
             f"❌ The tool call to [markdown.code]{message.tool_call['name']}[/] failed.",
             Markdown(f"```{message.str_content or '(No error provided)'}```"),
         )
-    elif not message.tool_metadata.get("is_task_status_tool"):
+    else:
         content_type = "json" if isinstance(message.tool_result, (dict, list)) else ""
         if len(message.str_content) > 3000:
             msg_content = (
@@ -139,8 +139,6 @@ def format_tool_message(message: ToolMessage, width: Optional[int] = None) -> Pa
             f"✅ Received output from the [markdown.code]{message.tool_call['name']}[/] tool.\n",
             Markdown(f"```{content_type}\n{msg_content}\n```"),
         )
-    else:
-        return ""
 
     return Panel(
         content,

--- a/src/controlflow/llm/messages.py
+++ b/src/controlflow/llm/messages.py
@@ -119,9 +119,10 @@ class ToolMessage(langchain_core.messages.ToolMessage, MessageMixin):
 
     role: Literal["tool"] = v1_Field("tool", exclude=True)
 
-    tool_call: ToolCall
+    tool_call: ToolCall = None
     tool_result: Any = v1_Field(exclude=True)
     tool_metadata: dict[str, Any] = v1_Field(default_factory=dict)
+    agent_id: str = v1_Field(None)
 
 
 class InvalidToolMessage(ToolMessage):

--- a/src/controlflow/llm/rules.py
+++ b/src/controlflow/llm/rules.py
@@ -13,10 +13,13 @@ class LLMRules:
     necessary.
     """
 
-    # messages
-    always_start_with_user_message: bool = False
-    allow_last_message_has_ai_role_with_tools: bool = True
+    # system messages can only be provided as the very first message in a thread
     system_message_must_be_first: bool = False
+    # other than a system message, the first message must be from the user
+    user_message_must_be_first_after_system: bool = False
+    # the last message in a thread can't be from an AI if tool use is allowed
+    allow_last_message_has_ai_role_with_tools: bool = True
+    # consecutive AI messages must be separated by a user message
     allow_consecutive_ai_messages: bool = True
 
 
@@ -25,8 +28,8 @@ class OpenAIRules(LLMRules):
 
 
 class AnthropicRules(LLMRules):
-    always_start_with_user_message: bool = True
     system_message_must_be_first: bool = True
+    user_message_must_be_first_after_system: bool = True
     allow_last_message_has_ai_role_with_tools: bool = False
     allow_consecutive_ai_messages: bool = False
 

--- a/src/controlflow/llm/tools.py
+++ b/src/controlflow/llm/tools.py
@@ -169,7 +169,10 @@ def output_to_string(output: Any) -> str:
 
 
 def handle_tool_call(
-    tool_call: ToolCall, tools: list[Tool], error: str = None
+    tool_call: ToolCall,
+    tools: list[Tool],
+    error: str = None,
+    agent_id: str = None,
 ) -> "ToolMessage":
     tool_lookup = {t.name: t for t in tools}
     fn_name = tool_call["name"]
@@ -201,11 +204,15 @@ def handle_tool_call(
         tool_call=tool_call,
         tool_result=fn_output,
         tool_metadata=metadata,
+        agent_id=agent_id,
     )
 
 
 async def handle_tool_call_async(
-    tool_call: ToolCall, tools: list[Tool], error: str = None
+    tool_call: ToolCall,
+    tools: list[Tool],
+    error: str = None,
+    agent_id: str = None,
 ) -> "ToolMessage":
     tool_lookup = {t.name: t for t in tools}
     fn_name = tool_call["name"]
@@ -235,14 +242,18 @@ async def handle_tool_call_async(
         tool_call=tool_call,
         tool_result=fn_output,
         tool_metadata=metadata,
+        agent_id=agent_id,
     )
 
 
-def handle_invalid_tool_call(tool_call: InvalidToolCall) -> "ToolMessage":
+def handle_invalid_tool_call(
+    tool_call: InvalidToolCall, agent_id: str = None
+) -> "ToolMessage":
     return InvalidToolMessage(
         content=tool_call["error"] or "",
         tool_call_id=tool_call["id"],
         tool_call=tool_call,
         tool_result=tool_call["error"],
         tool_metadata=dict(is_failed=True, is_invalid=True),
+        agent_id=agent_id,
     )

--- a/src/controlflow/tasks/task.py
+++ b/src/controlflow/tasks/task.py
@@ -472,7 +472,7 @@ class Task(ControlFlowModel):
             succeed,
             name=f"mark_task_{self.id}_successful",
             description=f"Mark task {self.id} as successful.",
-            metadata=dict(is_task_status_tool=True),
+            metadata=dict(ignore_result=True),
         )
 
     def _create_fail_tool(self) -> Tool:
@@ -484,7 +484,7 @@ class Task(ControlFlowModel):
             self.mark_failed,
             name=f"mark_task_{self.id}_failed",
             description=f"Mark task {self.id} as failed. Only use when technical errors prevent success.",
-            metadata=dict(is_task_status_tool=True),
+            metadata=dict(ignore_result=True),
         )
 
     def _create_skip_tool(self) -> Tool:
@@ -495,7 +495,7 @@ class Task(ControlFlowModel):
             self.mark_skipped,
             name=f"mark_task_{self.id}_skipped",
             description=f"Mark task {self.id} as skipped. Only use when completing a parent task early.",
-            metadata=dict(is_task_status_tool=True),
+            metadata=dict(ignore_result=True),
         )
 
     def get_agents(self) -> list["Agent"]:

--- a/src/controlflow/tools/code.py
+++ b/src/controlflow/tools/code.py
@@ -1,0 +1,29 @@
+# 🚨 WARNING 🚨
+# These functions allow ARBITRARY code execution and should be used with caution.
+
+import json
+import subprocess
+
+
+def shell(command: str) -> str:
+    """
+    Executes a shell command and returns the output
+
+    NOTE: this tool is not sandboxed and can execute arbitrary code. Be careful.
+    """
+    result = subprocess.run(command, shell=True, text=True, capture_output=True)
+
+    # Output and error
+    output = result.stdout
+    error = result.stderr
+
+    return json.dumps(dict(command_output=output, command_error=error))
+
+
+def python(code: str) -> str:
+    """
+    Executes Python code on the local machine and returns the output.
+
+    NOTE: this tool is not sandboxed and can execute arbitrary code. Be careful.
+    """
+    return str(eval(code))

--- a/src/controlflow/tools/filesystem.py
+++ b/src/controlflow/tools/filesystem.py
@@ -1,0 +1,295 @@
+import glob as glob_module
+import os
+import shutil
+from pathlib import Path
+
+
+def _safe_create_file(path: str) -> Path:
+    file_path = Path(path).expanduser()
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.touch(exist_ok=True)
+    return file_path
+
+
+def getcwd() -> str:
+    """Returns the current working directory"""
+    return os.getcwd()
+
+
+def write(path: str, contents: str) -> str:
+    """Creates or overwrites a file with the given contents"""
+    path = _safe_create_file(path)
+    path.write_text(contents)
+    return f'Successfully wrote "{path}"'
+
+
+def generate_constrained_write(root: str) -> str:
+    """
+    Returns a `write` function that will only write to files under the given root directory.
+    """
+
+    def constrained_write(path: str, contents: str) -> str:
+        """
+        Write `contents` to a `path`.
+        """
+        path: Path = Path(path).expanduser().absolute()
+        root_path = Path(root).expanduser().absolute()
+
+        if root_path not in path.parents:
+            raise ValueError(
+                f'Cannot write to "{path}". It\'s not under the root directory "{root_path}"'
+            )
+
+        return write(path, contents)
+
+    constrained_write.__doc__ = (
+        write.__doc__
+        + f'\n\nNote: this function is constrained to files under "{root}".'
+    )
+    return constrained_write
+
+
+def delete(path: str, is_dir: bool = False) -> str:
+    """Deletes a file or directory based on the is_dir flag."""
+    path = Path(path).expanduser()
+
+    if is_dir:
+        if path.is_dir():
+            shutil.rmtree(path)  # Recursively delete directory and its contents
+            return f'Successfully deleted directory "{path}"'
+        else:
+            return f'Error: "{path}" is not a directory.'
+    else:
+        if path.is_file():
+            path.unlink()  # Delete the file
+            return f'Successfully deleted "{path}"'
+        else:
+            return f'Error: "{path}" is not a file or does not exist.'
+
+
+def generate_constrained_delete(root: str) -> str:
+    """
+    Returns a `delete` function that will only write to files under the given root directory.
+    """
+
+    def constrained_delete(path: str, is_dir: bool = False) -> str:
+        """
+        Delete a file or directory at `path`.
+        """
+        path: Path = Path(path).expanduser().absolute()
+        root_path = Path(root).expanduser().absolute()
+
+        if root_path not in path.parents:
+            raise ValueError(
+                f'Cannot delete "{path}". It\'s not under the root directory "{root_path}"'
+            )
+
+        return delete(path, is_dir=is_dir)
+
+    constrained_delete.__doc__ = (
+        delete.__doc__
+        + f'\n\nNote: this function is constrained to files under "{root}".'
+    )
+
+    return constrained_delete
+
+
+def write_lines(
+    path: str, contents: str, insert_line: int = -1, mode: str = "insert"
+) -> str:
+    """Writes content to a specific line in the file.
+
+    Args:
+        path (str): The name of the file to write to.
+        contents (str): The content to write to the file.
+        insert_line (int, optional): The line number to insert the content at.
+            Negative values count from the end of the file. Defaults to -1.
+        mode (str, optional): The mode to use when writing the content. Can be
+            "insert" or "overwrite". Defaults to "insert".
+
+    Returns:
+        str: A message indicating whether the write was successful.
+    """
+    path = _safe_create_file(path)
+    with open(path, "r") as f:
+        lines = f.readlines()
+        if insert_line < 0:
+            insert_line = len(lines) + insert_line + 1
+        if mode == "insert":
+            lines[insert_line:insert_line] = contents.splitlines(True)
+        elif mode == "overwrite":
+            lines[insert_line : insert_line + len(contents.splitlines())] = (
+                contents.splitlines(True)
+            )
+        else:
+            raise ValueError(f"Invalid mode: {mode}")
+    with open(path, "w") as f:
+        f.writelines(lines)
+    return f'Successfully wrote to "{path}"'
+
+
+def read(path: str, include_line_numbers: bool = False) -> str:
+    """Reads a file and returns the contents.
+
+    Args:
+        path (str): The path to the file.
+        include_line_numbers (bool, optional): Whether to include line numbers
+            in the returned contents. Defaults to False.
+
+    Returns:
+        str: The contents of the file.
+    """
+    path = Path(path).expanduser()
+    with open(path, "r") as f:
+        if include_line_numbers:
+            lines = f.readlines()
+            lines_with_numbers = [f"{i+1}: {line}" for i, line in enumerate(lines)]
+            return "".join(lines_with_numbers)
+        else:
+            return f.read()
+
+
+def read_lines(
+    path: str,
+    start_line: int = 0,
+    end_line: int = -1,
+    include_line_numbers: bool = False,
+) -> str:
+    """Reads a partial file and returns the contents with optional line numbers.
+
+    Args:
+        path (str): The path to the file.
+        start_line (int, optional): The starting line number to read. Defaults
+            to 0.
+        end_line (int, optional): The ending line number to read. Defaults to
+            -1, which means read until the end of the file.
+        include_line_numbers (bool, optional): Whether to include line numbers
+            in the returned contents. Defaults to False.
+
+    Returns:
+        str: The contents of the file.
+    """
+    path = os.path.expanduser(path)
+    with open(path, "r") as f:
+        lines = f.readlines()
+        if start_line < 0:
+            start_line = len(lines) + start_line
+        if end_line < 0:
+            end_line = len(lines) + end_line
+        if include_line_numbers:
+            lines_with_numbers = [
+                f"{i+1}: {line}" for i, line in enumerate(lines[start_line:end_line])
+            ]
+            return "".join(lines_with_numbers)
+        else:
+            return "".join(lines[start_line:end_line])
+
+
+def mkdir(path: str) -> str:
+    """Creates a directory (and any parent directories))"""
+    path = Path(path).expanduser()
+    path.mkdir(parents=True, exist_ok=True)
+    return f'Successfully created directory "{path}"'
+
+
+def mv(src: str, dest: str) -> str:
+    """Moves a file or directory"""
+    src = Path(src).expanduser()
+    dest = Path(dest).expanduser()
+    src.rename(dest)
+    return f'Successfully moved "{src}" to "{dest}"'
+
+
+def cp(src: str, dest: str) -> str:
+    """Copies a file or directory"""
+    src = Path(src).expanduser()
+    dest = Path(dest).expanduser()
+    shutil.copytree(src, dest)
+    return f'Successfully copied "{src}" to "{dest}"'
+
+
+def ls(path: str) -> str:
+    """Lists the contents of a directory"""
+    path = Path(path).expanduser()
+    return "\n".join(str(p) for p in path.iterdir())
+
+
+def glob(pattern: str) -> list[str]:
+    """
+    Returns a list of paths matching a valid glob pattern. The pattern can
+    include ** for recursive matching, such as '/path/**/dir/*.py'. Only simple
+    glob patterns are supported, compound queries like '/path/*.{py, md}' are
+    NOT supported.
+    """
+    return glob_module.glob(pattern, recursive=True)
+
+
+def concat(source_paths: list[str], dest_path: str, add_headers: bool = True) -> str:
+    """
+    Concatenates the contents of multiple source files into a single destination
+    file. The result should be markdown. If add_headers is True, the file path
+    will be added as a header above the contents of each file.
+
+    Note that source paths can include simple glob patterns, such as
+    '/path/**/dir/*.py'. Compound queries like '/path/*.{py, md}' are NOT
+    supported.
+    """
+    # source_paths can include glob patterns
+    source_paths = [path for pattern in source_paths for path in glob(pattern)]
+
+    dest_path = _safe_create_file(dest_path)
+    with open(dest_path, "w") as dest_file:
+        for source_path in source_paths:
+            source_path = os.path.expanduser(source_path)
+            if add_headers:
+                dest_file.write(f"\n\n# File: {source_path}\n")
+            with open(source_path, "r") as source_file:
+                dest_file.write(source_file.read())
+    return f'Successfully concatenated files to "{dest_path}"'
+
+
+def generate_constrained_concat(root: str) -> callable:
+    """
+    Returns a `concat` function that will only concatenate files under the given root directory.
+    """
+
+    def constrained_concat(
+        source_paths: list[str], dest_path: str, add_headers: bool = True
+    ) -> str:
+        root_path = Path(root).expanduser().absolute()
+
+        # Check if destination path is under root directory
+        dest_path_abs = Path(dest_path).expanduser().absolute()
+        if root_path not in dest_path_abs.parents and dest_path_abs != root_path:
+            raise ValueError(
+                f'Cannot write to "{dest_path_abs}". It\'s not under the root directory "{root_path}"'
+            )
+
+        # Proceed with concatenation
+        return concat(source_paths, dest_path, add_headers=add_headers)
+
+    constrained_concat.__doc__ = (
+        concat.__doc__
+        + f'\n\nNote: this function is constrained to files under "{root}".'
+    )
+
+    return constrained_concat
+
+
+READ_TOOLS = [
+    getcwd,
+    read,
+    read_lines,
+    ls,
+    glob,
+]
+
+WRITE_TOOLS = [
+    write,
+    write_lines,
+    mkdir,
+    mv,
+    cp,
+    delete,
+    concat,
+]

--- a/src/controlflow/tools/web.py
+++ b/src/controlflow/tools/web.py
@@ -1,0 +1,28 @@
+import httpx
+from markdownify import markdownify as md
+
+
+def get_url(
+    url: str, clean: bool = True, clean_images: bool = True, clean_links: bool = False
+) -> str:
+    """
+    Make a GET request to the given URL, exactly as provided,
+    and return the response text.
+
+    If clean is True, the response text is converted from HTML to a
+    Markdown-like format that removes extraneous tags. The `clean_images`
+    (removes image tags) and `clean_links` (removes link tags) parameters can be
+    used to further clean the text.
+
+    Raises an exception if the response status code is not 2xx.
+    """
+    response = httpx.get(url)
+    response.raise_for_status()
+    if clean:
+        strip = []
+        if clean_images:
+            strip.append("img")
+        if clean_links:
+            strip.append("a")
+        return md(response.text, strip=strip)
+    return response.text

--- a/tests/llm/test_tools.py
+++ b/tests/llm/test_tools.py
@@ -228,3 +228,28 @@ class TestHandleTools:
         message = handle_invalid_tool_call(tool_call, tools=[])
         assert message.content == 'Function "foo" not found.'
         assert message.tool_metadata["is_failed"]
+
+    def handle_tool_call_with_agent_id(self):
+        @tool
+        def foo():
+            return 2
+
+        tool_call = {"name": "foo", "args": {}}
+        message = handle_tool_call(tool_call, tools=[foo], agent_id="test-agent")
+        assert message.agent_id == "test-agent"
+
+    async def handle_async_tool_call_with_agent_id(self):
+        @tool
+        async def foo():
+            return 2
+
+        tool_call = {"name": "foo", "args": {}}
+        message = await handle_tool_call_async(
+            tool_call, tools=[foo], agent_id="test-agent"
+        )
+        assert message.agent_id == "test-agent"
+
+    def handle_invalid_tool_call_with_agent_id(self):
+        tool_call = {"name": "foo", "args": {}}
+        message = handle_invalid_tool_call(tool_call, tools=[], agent_id="test-agent")
+        assert message.agent_id == "test-agent"


### PR DESCRIPTION
This hides tool call results from agents that didn't make the call. 

For example, if agent 1 delegates agent 2 to read a large document and summarize it, the tool call loading the entire document into agent 2's context shouldn't pollute agent 1. 