### PR TITLE
Handle missing API key more gracefully

### DIFF
--- a/src/controlflow/__init__.py
+++ b/src/controlflow/__init__.py
@@ -12,12 +12,12 @@ from .llm.tools import tool
 
 # --- Default settings ---
 
-from .llm.models import model_from_string, get_default_model
+from .llm.models import get_default_model, _get_initial_default_model
 from .flows.history import InMemoryHistory, get_default_history
 
 # assign to controlflow.default_model to change the default model
-default_model = model_from_string(settings.llm_model)
-del model_from_string
+default_model = _get_initial_default_model()
+del _get_initial_default_model
 
 # assign to controlflow.default_history to change the default history
 default_history = InMemoryHistory()

--- a/src/controlflow/agents/agent.py
+++ b/src/controlflow/agents/agent.py
@@ -87,7 +87,12 @@ class Agent(ControlFlowModel):
         """
         Retrieve the LLM model for this agent
         """
-        return self.model or get_default_model()
+        try:
+            return self.model or get_default_model()
+        except Exception as exc:
+            raise ValueError(
+                f"Agent {self.name}: No model provided and no default model could be loaded: {exc}"
+            ) from exc
 
     def get_llm_rules(self) -> LLMRules:
         """

--- a/src/controlflow/llm/models.py
+++ b/src/controlflow/llm/models.py
@@ -1,10 +1,15 @@
+import inspect
 from typing import Any, Optional
 
 from langchain_anthropic import ChatAnthropic
 from langchain_core.language_models import BaseChatModel
 from langchain_openai import ChatOpenAI
+from pydantic import ValidationError
 
 import controlflow
+from controlflow.utilities.logging import get_logger
+
+logger = get_logger(__name__)
 
 
 def get_default_model() -> BaseChatModel:
@@ -49,3 +54,32 @@ def model_from_string(
 
 
 DEFAULT_MODEL = None
+
+
+def _get_initial_default_model() -> BaseChatModel:
+    # special error messages for the initial attempt to create a model
+    try:
+        return model_from_string(controlflow.settings.llm_model)
+    except Exception as exc:
+        if isinstance(exc, ValidationError) and "Did not find openai_api_key" in str(
+            exc
+        ):
+            msg = inspect.cleandoc("""
+                The default LLM model could not be created because the OpenAI
+                API key was not found. ControlFlow will continue to work, but
+                you must manually provide an LLM model for each agent. Please
+                set the OPENAI_API_KEY environment variable or choose a
+                different default LLM model. For more information, please see
+                https://controlflow.ai/guides/llms.
+                """).replace("\n", " ")
+        else:
+            msg = (
+                inspect.cleandoc("""
+                The default LLM model could not be created. ControlFlow will
+                continue to work, but you must manually provide an LLM model for
+                each agent. For more information, please see
+                https://controlflow.ai/guides/llms. The error was:
+                """).replace("\n", " ")
+                + f"\n{exc}"
+            )
+        logger.warn(msg)

--- a/src/controlflow/llm/tools.py
+++ b/src/controlflow/llm/tools.py
@@ -77,7 +77,7 @@ class Tool(ControlFlowModel):
     def from_function(
         cls, fn: Callable, name: str = None, description: str = None, **kwargs
     ):
-        description = description or fn.__doc__ or ""
+        description = description or fn.__doc__ or "(No description provided)"
 
         signature = inspect.signature(fn)
         parameters = TypeAdapter(fn).json_schema()

--- a/tests/llm/test_tools.py
+++ b/tests/llm/test_tools.py
@@ -45,7 +45,7 @@ class TestToolFunctions:
         elif style == "decorator":
             roll_die_tool = tool(roll_die)
 
-        assert roll_die_tool.description == "roll_die"
+        assert roll_die_tool.description == "(No description provided)"
 
     def test_tool_gets_docstring_from_description(self, style):
         def roll_die():

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,4 +1,7 @@
+import importlib
+
 import controlflow
+import pytest
 from controlflow.settings import temporary_settings
 from prefect.logging import get_logger
 
@@ -22,3 +25,62 @@ def test_prefect_settings_apply_at_runtime(caplog):
     assert "test-log-1" in caplog.text
     assert "test-log-2" not in caplog.text
     assert "test-log-3" in caplog.text
+
+
+def test_import_without_default_api_key_warns_but_does_not_fail(monkeypatch, caplog):
+    # remove the OPENAI_API_KEY environment variable
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    # Clear any previous logs
+    caplog.clear()
+
+    # Import the library
+    with caplog.at_level("WARNING"):
+        # Reload the library to apply changes
+        importlib.reload(controlflow)
+
+    # Check if the warning was logged
+    assert any(
+        record.levelname == "WARNING"
+        and "The default LLM model could not be created" in record.message
+        for record in caplog.records
+    ), "The expected warning was not logged"
+
+
+def test_import_without_default_api_key_errors_when_loading_model(monkeypatch):
+    # remove the OPENAI_API_KEY environment variable
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    # Reload the library to apply changes
+    importlib.reload(controlflow)
+
+    with pytest.raises(ValueError, match="Did not find openai_api_key"):
+        controlflow.get_default_model()
+
+    with pytest.raises(
+        ValueError, match="No model provided and no default model could be loaded"
+    ):
+        controlflow.Agent().get_model()
+
+
+def test_import_without_api_key_for_non_default_model_warns_but_does_not_fail(
+    monkeypatch, caplog
+):
+    # remove the OPENAI_API_KEY environment variable
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("CONTROLFLOW_LLM_MODEL", "anthropic/not-a-model")
+
+    # Clear any previous logs
+    caplog.clear()
+
+    # Import the library
+    with caplog.at_level("WARNING"):
+        # Reload the library to apply changes
+        importlib.reload(controlflow)
+
+    # Check if the warning was logged
+    assert any(
+        record.levelname == "WARNING"
+        and "The default LLM model could not be created" in record.message
+        for record in caplog.records
+    ), "The expected warning was not logged"


### PR DESCRIPTION
Closes #169 

If you import CF and the default model can't be set (usually/probably because you didn't set the API key env var), a friendly warning is logged but the library doesn't crash. It will crash, however, if you try to use an agent without providing a valid model.