### PR TITLE
Update langchain-core required version

### DIFF
--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -139,7 +139,7 @@ jsonschema-specifications==2023.12.1
     # via jsonschema
 langchain-anthropic==0.1.15
     # via controlflow
-langchain-core==0.2.4
+langchain-core==0.2.9
     # via controlflow
     # via langchain-anthropic
     # via langchain-openai


### PR DESCRIPTION
Langchain-core was throwing an error around trim_messages.  Updating to 0.2.9 resolves it for me. 
```
from langchain_core.messages.utils import trim_messages
ImportError: cannot import name 'trim_messages' from 'langchain_core.messages.utils' (/Users/jennifer/opt/anaconda3/envs/py312/lib/python3.12/site-packages/langchain_core/messages/utils.py)
```