### PR TITLE
platform independent timestamp

### DIFF
--- a/src/controlflow/handlers/print_handler.py
+++ b/src/controlflow/handlers/print_handler.py
@@ -104,7 +104,7 @@ class PrintHandler(CompletionHandler):
 
 def format_timestamp(timestamp: datetime.datetime) -> str:
     local_timestamp = timestamp.astimezone()
-    return local_timestamp.strftime("%l:%M:%S %p")
+    return local_timestamp.strftime("%I:%M:%S %p").lstrip("0").rjust(11)
 
 
 def status(icon, text) -> Table:


### PR DESCRIPTION
`%l` gives 12-hour format with a leading space if H < 10 but doesnt work on windows and some linux

`%I` is the closest platform independent analog but requires some wrangling to give the desired format

closes concern raised in [this](https://github.com/PrefectHQ/ControlFlow/issues/189#issuecomment-2195613805) comment and see similar issue [here](https://github.com/PrefectHQ/marvin/pull/937)

#### behavior after this PR
```python
In [1]: import datetime

In [2]: def format_timestamp(timestamp: datetime.datetime) -> str:
   ...:     local_timestamp = timestamp.astimezone()
   ...:     return local_timestamp.strftime("%I:%M:%S %p").lstrip("0").rjust(11)
   ...:

In [3]: format_timestamp(datetime.datetime.fromtimestamp(123456))
Out[3]: ' 4:17:36 AM'
```

<img width="807" alt="image" src="https://github.com/PrefectHQ/ControlFlow/assets/31014960/d8cafbce-2357-4421-b6cd-69c7b6e89fc5">
