### PR TITLE
move defaults out of root

### DIFF
--- a/docs/guides/default-agent.mdx
+++ b/docs/guides/default-agent.mdx
@@ -8,7 +8,7 @@ ControlFlow uses a default agent when no specific agents are assigned to a task.
 
 The global default agent (whose name, of course, is Marvin) uses whatever [default model](/guides/llms#changing-the-default-model) you've configured. It has a basic set of general-purpose instructions and is not equipped with any tools.
 
-To change the global default agent, assign a new agent to the `default_agent` attribute of the `controlflow` module:
+To change the global default agent, assign a new agent to `controlflow.defaults.agent`:
 
 ```python
 import controlflow as cf
@@ -17,7 +17,7 @@ import controlflow as cf
 agent = cf.Agent('Deep Thought', instructions='Answer every question with 42')
 
 # Set the global default agent
-cf.default_agent = agent
+cf.defaults.agent = agent
 
 # Create a task without specifying an agent
 task = cf.Task('What is 2 + 2?')
@@ -53,7 +53,7 @@ When ControlFlow needs to assign an agent to a task, it follows this precedence:
 
 1. Agents specified directly on the task (`task.agents`)
 2. Agents specified for the flow (`@flow(agents=[...])`)
-3. The global default agent (`cf.default_agent`)
+3. The global default agent (`controlflow.defaults.agent`)
 
 This means you can always override the default agent by specifying agents directly on a task, regardless of what default agents are set at the flow or global level.
 
@@ -61,7 +61,7 @@ This means you can always override the default agent by specifying agents direct
 import controlflow as cf
 
 global_agent = cf.Agent('Global', instructions='I am the global default')
-cf.default_agent = global_agent
+cf.defaults.agent = global_agent
 
 flow_agent = cf.Agent('Flow', instructions='I am the flow default')
 

--- a/docs/guides/llms.mdx
+++ b/docs/guides/llms.mdx
@@ -131,25 +131,28 @@ assert cf.Agent('Marvin').model.model_name == 'claude-3-opus-20240229'
 ```
 ### From a string setting
 
-If you don't need to configure the model object, you can set the default model using a string setting. The string must have the form `<provider>/<model name>`.
+You can also specify a default model using a string, which is convenient though it doesn't allow you to configure advanced model settings. The string must have the form `<provider>/<model name>`.
 
-
-You can change this setting either with an environment variable or by modifying it in your script. For example, to use GPT 3.5 Turbo as the default model:
+You can apply this setting either by using an environment variable before you import ControlFlow or in your script at runtime. For example, to use GPT 3.5 Turbo as the default model:
 
 <CodeGroup>
-```bash As an environment variable
+```bash Set an environment variable
 export CONTROLFLOW_LLM_MODEL=openai/gpt-3.5-turbo
 ```
 
-```python In your script
+```python Set a runtime variable
 import controlflow as cf
-# set the default model
-cf.settings.llm_model = "openai/gpt-3.5-turbo"
+# set the default model as a string
+cf.defaults.model = "openai/gpt-3.5-turbo"
 
 # check that the default model is loaded
 assert cf.Agent('Marvin').model.model_name == 'gpt-3.5-turbo'
 ```
 </CodeGroup>
+
+<Note>
+The default model can only be set by environment variable before importing ControlFlow. Once ControlFlow is imported, it reads the `controlflow.settings.llm_model` value to create the default model object.
+</Note>
 
 
 At this time, setting the default model via string is only supported for the following providers:

--- a/docs/guides/llms.mdx
+++ b/docs/guides/llms.mdx
@@ -114,14 +114,14 @@ ControlFlow includes OpenAI and Azure OpenAI models by default. To use other mod
 
 ### From a model object
 
-To use any model as the default LLM, create the model object in your script and assign it to controlflow's `default_model` attribute. It will be used by any agent that does not have a model specified.
+To use any model as the default LLM, create the model object in your script and assign it to `controlflow.defaults.model`. It will be used by any agent that does not have a model specified.
 
 ```python
 import controlflow as cf
 from langchain_anthropic import ChatAnthropic
 
 # set the default model
-cf.default_model = ChatAnthropic(
+cf.defaults.model = ChatAnthropic(
     model='claude-3-opus-20240229', 
     temperature=0.1,
 )

--- a/src/controlflow/__init__.py
+++ b/src/controlflow/__init__.py
@@ -1,6 +1,8 @@
 # --- Public top-level API ---
 
+from pyexpat import model
 from .settings import settings
+from controlflow.defaults import defaults
 
 from .agents import Agent
 from .tasks import Task
@@ -9,24 +11,8 @@ from .flows import Flow
 from .instructions import instructions
 from .decorators import flow, task
 from .tools import tool
-
-# --- Default settings ---
-
-from .llm.models import _get_initial_default_model, get_default_model
-from .events.history import InMemoryHistory, get_default_history
-
-# assign to controlflow.default_model to change the default model
-default_model = _get_initial_default_model()
-del _get_initial_default_model
-
-# assign to controlflow.default_history to change the default history
-default_history = InMemoryHistory()
-del InMemoryHistory
-
-# assign to controlflow.default_agent to change the default agent
-default_agent = Agent(name="Marvin")
-
 # --- Version ---
+
 
 try:
     from ._version import version as __version__  # type: ignore

--- a/src/controlflow/__init__.py
+++ b/src/controlflow/__init__.py
@@ -1,6 +1,9 @@
 # --- Public top-level API ---
 
 from pyexpat import model
+
+
+from langchain_core.language_models import BaseChatModel
 from .settings import settings
 from controlflow.defaults import defaults
 
@@ -18,3 +21,12 @@ try:
     from ._version import version as __version__  # type: ignore
 except ImportError:
     __version__ = "unknown"
+
+
+# def get_default_model() -> BaseChatModel:
+#     from controlflow.llm.models import model_from_string
+
+#     if getattr(defaults, "model", None) is None:
+#         return model_from_string(settings.llm_model)
+#     else:
+#         return defaults.model

--- a/src/controlflow/agents/__init__.py
+++ b/src/controlflow/agents/__init__.py
@@ -1,2 +1,2 @@
 from . import memory
-from .agent import Agent, get_default_agent
+from .agent import Agent

--- a/src/controlflow/agents/agent.py
+++ b/src/controlflow/agents/agent.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 
 
 def get_default_agent() -> "Agent":
-    return controlflow.default_agent
+    return controlflow.defaults.agent
 
 
 class Agent(ControlFlowModel):

--- a/src/controlflow/agents/agent.py
+++ b/src/controlflow/agents/agent.py
@@ -11,7 +11,6 @@ import controlflow
 from controlflow.events.events import Event
 from controlflow.instructions import get_instructions
 from controlflow.llm.messages import AIMessage, BaseMessage
-from controlflow.llm.models import get_default_model
 from controlflow.llm.rules import LLMRules
 from controlflow.tools.tools import handle_tool_call_async
 from controlflow.utilities.context import ctx
@@ -25,10 +24,6 @@ if TYPE_CHECKING:
     from controlflow.tools.tools import Tool
 
 logger = logging.getLogger(__name__)
-
-
-def get_default_agent() -> "Agent":
-    return controlflow.defaults.agent
 
 
 class Agent(ControlFlowModel):
@@ -99,12 +94,12 @@ class Agent(ControlFlowModel):
         """
         Retrieve the LLM model for this agent
         """
-        try:
-            return self.model or get_default_model()
-        except Exception as exc:
+        model = self.model or controlflow.defaults.model
+        if model is None:
             raise ValueError(
-                f"Agent {self.name}: No model provided and no default model could be loaded: {exc}"
-            ) from exc
+                f"Agent {self.name}: No model provided and no default model could be loaded."
+            )
+        return model
 
     def get_llm_rules(self) -> LLMRules:
         """

--- a/src/controlflow/defaults.py
+++ b/src/controlflow/defaults.py
@@ -1,0 +1,50 @@
+from typing import Any
+
+from pydantic import field_validator
+
+import controlflow
+import controlflow.utilities
+import controlflow.utilities.logging
+from controlflow.llm.models import BaseChatModel
+from controlflow.utilities.types import ControlFlowModel
+
+from .agents import Agent
+from .events.history import History, InMemoryHistory
+from .llm.models import _get_initial_default_model
+
+__all__ = ["defaults"]
+
+logger = controlflow.utilities.logging.get_logger(__name__)
+
+
+class Defaults(ControlFlowModel):
+    """
+    This class holds the default values for various parts of the ControlFlow
+    library.
+
+    Note that users should interact with the `defaults` object directly, rather
+    than instantiating this class. It is intended to be created once, when ControlFlow
+    is imported, and then used as a singleton.
+    """
+
+    model: Any
+    history: History
+    agent: Agent
+    # add more defaults here
+
+    def __repr__(self) -> str:
+        fields = ", ".join(self.model_fields.keys())
+        return f"<ControlFlow Defaults: {fields}>"
+
+    @field_validator("model")
+    def _model(cls, v):
+        if not isinstance(v, BaseChatModel):
+            raise ValueError("model must be a BaseChatModel")
+        return v
+
+
+defaults = Defaults(
+    model=_get_initial_default_model(),
+    history=InMemoryHistory(),
+    agent=Agent(name="Marvin"),
+)

--- a/src/controlflow/defaults.py
+++ b/src/controlflow/defaults.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Optional
 
 from pydantic import field_validator
 
@@ -10,7 +10,7 @@ from controlflow.utilities.types import ControlFlowModel
 
 from .agents import Agent
 from .events.history import History, InMemoryHistory
-from .llm.models import _get_initial_default_model
+from .llm.models import _get_initial_default_model, model_from_string
 
 __all__ = ["defaults"]
 
@@ -27,7 +27,7 @@ class Defaults(ControlFlowModel):
     is imported, and then used as a singleton.
     """
 
-    model: Any
+    model: Optional[Any]
     history: History
     agent: Agent
     # add more defaults here
@@ -38,7 +38,9 @@ class Defaults(ControlFlowModel):
 
     @field_validator("model")
     def _model(cls, v):
-        if not isinstance(v, BaseChatModel):
+        if isinstance(v, str):
+            v = model_from_string(v)
+        elif v is not None and v is not isinstance(v, BaseChatModel):
             raise ValueError("Input must be an instance of BaseChatModel")
         return v
 

--- a/src/controlflow/defaults.py
+++ b/src/controlflow/defaults.py
@@ -40,7 +40,7 @@ class Defaults(ControlFlowModel):
     def _model(cls, v):
         if isinstance(v, str):
             v = model_from_string(v)
-        elif v is not None and v is not isinstance(v, BaseChatModel):
+        elif v is not None and not isinstance(v, BaseChatModel):
             raise ValueError("Input must be an instance of BaseChatModel")
         return v
 

--- a/src/controlflow/defaults.py
+++ b/src/controlflow/defaults.py
@@ -39,7 +39,7 @@ class Defaults(ControlFlowModel):
     @field_validator("model")
     def _model(cls, v):
         if not isinstance(v, BaseChatModel):
-            raise ValueError("model must be a BaseChatModel")
+            raise ValueError("Input must be an instance of BaseChatModel")
         return v
 
 

--- a/src/controlflow/events/history.py
+++ b/src/controlflow/events/history.py
@@ -28,7 +28,7 @@ IN_MEMORY_STORE = {}
 
 
 def get_default_history() -> "History":
-    return controlflow.default_history
+    return controlflow.defaults.history
 
 
 @cache

--- a/src/controlflow/events/history.py
+++ b/src/controlflow/events/history.py
@@ -27,10 +27,6 @@ if TYPE_CHECKING:
 IN_MEMORY_STORE = {}
 
 
-def get_default_history() -> "History":
-    return controlflow.defaults.history
-
-
 @cache
 def get_event_validator() -> TypeAdapter:
     types = Union[

--- a/src/controlflow/llm/models.py
+++ b/src/controlflow/llm/models.py
@@ -13,10 +13,10 @@ logger = get_logger(__name__)
 
 
 def get_default_model() -> BaseChatModel:
-    if getattr(controlflow, "default_model", None) is None:
+    if getattr(controlflow.defaults, "model", None) is None:
         return model_from_string(controlflow.settings.llm_model)
     else:
-        return controlflow.default_model
+        return controlflow.defaults.model
 
 
 def model_from_string(
@@ -59,9 +59,6 @@ def model_from_string(
         )
 
     return cls(model=model, temperature=temperature, **kwargs)
-
-
-DEFAULT_MODEL = None
 
 
 def _get_initial_default_model() -> BaseChatModel:

--- a/src/controlflow/tasks/task.py
+++ b/src/controlflow/tasks/task.py
@@ -430,7 +430,6 @@ class Task(ControlFlowModel):
         elif self.parent:
             return self.parent.get_agents()
         else:
-            from controlflow.agents import get_default_agent
             from controlflow.flows import get_flow
 
             try:
@@ -440,7 +439,7 @@ class Task(ControlFlowModel):
             if flow and flow.agents:
                 return flow.agents
             else:
-                return [get_default_agent()]
+                return [controlflow.defaults.agent]
 
     def get_agent_strategy(self) -> Callable:
         """

--- a/src/controlflow/utilities/testing.py
+++ b/src/controlflow/utilities/testing.py
@@ -33,15 +33,15 @@ def record_events():
 
     """
     history = InMemoryHistory(history={})
-    old_default_history = controlflow.default_history
-    controlflow.default_history = history
+    old_default_history = controlflow.defaults.history
+    controlflow.defaults.history = history
 
     events = []
 
     try:
         yield events
     finally:
-        controlflow.default_history = old_default_history
+        controlflow.defaults.history = old_default_history
 
         _events_buffer = []
         for _, thread_events in history.history.items():

--- a/tests/agents/test_agents.py
+++ b/tests/agents/test_agents.py
@@ -1,5 +1,5 @@
 import controlflow
-from controlflow.agents import Agent, get_default_agent
+from controlflow.agents import Agent
 from controlflow.agents.names import NAMES
 from controlflow.instructions import instructions
 from controlflow.tasks.task import Task
@@ -17,7 +17,7 @@ class TestAgentInitialization:
 
         # None indicates it will be loaded from the default model
         assert agent.model is None
-        assert agent.get_model() is controlflow.get_default_model()
+        assert agent.get_model() is controlflow.defaults.model
 
     def test_agent_model(self):
         model = ChatOpenAI(model="gpt-3.5-turbo")
@@ -36,23 +36,23 @@ class TestAgentInitialization:
 
 class TestDefaultAgent:
     def test_default_agent(self):
-        assert get_default_agent().name == "Marvin"
-        assert Task("task").get_agents()[0] is get_default_agent()
+        assert controlflow.defaults.agent.name == "Marvin"
+        assert Task("task").get_agents()[0] is controlflow.defaults.agent
 
     def test_default_agent_has_no_tools(self):
-        assert get_default_agent().tools == []
+        assert controlflow.defaults.agent.tools == []
 
     def test_default_agent_has_no_model(self):
-        assert get_default_agent().model is None
+        assert controlflow.defaults.agent.model is None
 
     def test_default_agent_can_be_assigned(self):
         # baseline
-        assert get_default_agent().name == "Marvin"
+        assert controlflow.defaults.agent.name == "Marvin"
 
         new_default_agent = Agent(name="New Agent")
         controlflow.defaults.agent = new_default_agent
 
-        assert get_default_agent().name == "New Agent"
+        assert controlflow.defaults.agent.name == "New Agent"
         assert Task("task").get_agents()[0] is new_default_agent
         assert [a.name for a in Task("task").get_agents()] == ["New Agent"]
 
@@ -60,7 +60,7 @@ class TestDefaultAgent:
         new_model = ChatOpenAI(model="gpt-3.5-turbo")
         controlflow.defaults.model = new_model
 
-        new_agent = get_default_agent()
+        new_agent = controlflow.defaults.agent
         assert new_agent.model is None
         assert new_agent.get_model() is new_model
 

--- a/tests/agents/test_agents.py
+++ b/tests/agents/test_agents.py
@@ -50,7 +50,7 @@ class TestDefaultAgent:
         assert get_default_agent().name == "Marvin"
 
         new_default_agent = Agent(name="New Agent")
-        controlflow.default_agent = new_default_agent
+        controlflow.defaults.agent = new_default_agent
 
         assert get_default_agent().name == "New Agent"
         assert Task("task").get_agents()[0] is new_default_agent
@@ -58,7 +58,7 @@ class TestDefaultAgent:
 
     def test_updating_the_default_model_updates_the_default_agent_model(self):
         new_model = ChatOpenAI(model="gpt-3.5-turbo")
-        controlflow.default_model = new_model
+        controlflow.defaults.model = new_model
 
         new_agent = get_default_agent()
         assert new_agent.model is None

--- a/tests/fixtures/controlflow.py
+++ b/tests/fixtures/controlflow.py
@@ -9,9 +9,9 @@ def restore_defaults(monkeypatch):
     """
     Monkeypatch defaults to themselves, which will automatically reset them after every test
     """
-    monkeypatch.setattr(controlflow, "default_agent", controlflow.default_agent)
-    monkeypatch.setattr(controlflow, "default_model", controlflow.default_model)
-    monkeypatch.setattr(controlflow, "default_history", controlflow.default_history)
+    monkeypatch.setattr(controlflow.defaults, "agent", controlflow.defaults.agent)
+    monkeypatch.setattr(controlflow.defaults, "model", controlflow.defaults.model)
+    monkeypatch.setattr(controlflow.defaults, "history", controlflow.defaults.history)
     yield
 
 
@@ -22,5 +22,5 @@ def fake_llm() -> FakeLLM:
 
 @pytest.fixture()
 def default_fake_llm(fake_llm) -> FakeLLM:
-    controlflow.default_model = fake_llm
+    controlflow.defaults.model = fake_llm
     return fake_llm

--- a/tests/tasks/test_tasks.py
+++ b/tests/tasks/test_tasks.py
@@ -1,7 +1,8 @@
 from functools import partial
 
+import controlflow
 import pytest
-from controlflow.agents import Agent, get_default_agent
+from controlflow.agents import Agent
 from controlflow.flows import Flow
 from controlflow.instructions import instructions
 from controlflow.tasks.task import Task, TaskStatus
@@ -106,7 +107,7 @@ def test_task_loads_agent_from_parent():
 
 
 def test_task_loads_agent_from_flow():
-    def_agent = get_default_agent()
+    def_agent = controlflow.defaults.agent
     agent = Agent(name="Test Agent")
     with Flow(agents=[agent]):
         task = SimpleTask()
@@ -119,7 +120,7 @@ def test_task_loads_agent_from_flow():
 
 
 def test_task_loads_agent_from_default_if_none_otherwise():
-    agent = get_default_agent()
+    agent = controlflow.defaults.agent
     task = SimpleTask()
 
     assert task.agents is None

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -16,7 +16,7 @@ def test_default_model_failed_validation():
 def test_set_default_model():
     model = ChatOpenAI(temperature=0.1)
     controlflow.defaults.model = model
-    assert controlflow.llm.models.get_default_model() is model
+    assert controlflow.Agent().get_model() is model
 
 
 def test_default_agent_failed_validation():
@@ -30,7 +30,7 @@ def test_default_agent_failed_validation():
 def test_set_default_agent():
     agent = controlflow.Agent(name="Marvin")
     controlflow.defaults.agent = agent
-    assert controlflow.agents.get_default_agent() is agent
+    assert controlflow.Task("").get_agents()[0] is agent
 
 
 def test_default_history_failed_validation():
@@ -44,4 +44,4 @@ def test_default_history_failed_validation():
 def test_set_default_history():
     history = controlflow.events.history.InMemoryHistory()
     controlflow.defaults.history = history
-    assert controlflow.events.history.get_default_history() is history
+    assert controlflow.Flow().history is history

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -1,0 +1,47 @@
+import controlflow
+import controlflow.events.history
+import controlflow.llm
+import pydantic
+import pytest
+from langchain_openai import ChatOpenAI
+
+
+def test_default_model_failed_validation():
+    with pytest.raises(
+        pydantic.ValidationError, match="Input must be an instance of BaseChatModel"
+    ):
+        controlflow.defaults.model = 5
+
+
+def test_set_default_model():
+    model = ChatOpenAI(temperature=0.1)
+    controlflow.defaults.model = model
+    assert controlflow.llm.models.get_default_model() is model
+
+
+def test_default_agent_failed_validation():
+    with pytest.raises(
+        pydantic.ValidationError,
+        match="Input should be a valid dictionary or instance of Agent",
+    ):
+        controlflow.defaults.agent = 5
+
+
+def test_set_default_agent():
+    agent = controlflow.Agent(name="Marvin")
+    controlflow.defaults.agent = agent
+    assert controlflow.agents.get_default_agent() is agent
+
+
+def test_default_history_failed_validation():
+    with pytest.raises(
+        pydantic.ValidationError,
+        match="Input should be a valid dictionary or instance of History",
+    ):
+        controlflow.defaults.history = 5
+
+
+def test_set_default_history():
+    history = controlflow.events.history.InMemoryHistory()
+    controlflow.defaults.history = history
+    assert controlflow.events.history.get_default_history() is history

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,6 +1,7 @@
 import importlib
 
 import controlflow
+import controlflow.llm.models
 import pytest
 from controlflow.settings import temporary_settings
 from prefect.logging import get_logger
@@ -43,7 +44,9 @@ def test_import_without_default_api_key_warns_but_does_not_fail(monkeypatch, cap
     # Import the library
     with caplog.at_level("WARNING"):
         # Reload the library to apply changes
+        defaults_module = importlib.import_module("controlflow.defaults")
         importlib.reload(controlflow)
+        importlib.reload(defaults_module)
 
     # Check if the warning was logged
     assert any(
@@ -58,10 +61,12 @@ def test_import_without_default_api_key_errors_when_loading_model(monkeypatch):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
 
     # Reload the library to apply changes
+    defaults_module = importlib.import_module("controlflow.defaults")
     importlib.reload(controlflow)
+    importlib.reload(defaults_module)
 
     with pytest.raises(ValueError, match="Did not find openai_api_key"):
-        controlflow.get_default_model()
+        controlflow.llm.models.get_default_model()
 
     with pytest.raises(
         ValueError, match="No model provided and no default model could be loaded"
@@ -82,7 +87,9 @@ def test_import_without_api_key_for_non_default_model_warns_but_does_not_fail(
     # Import the library
     with caplog.at_level("WARNING"):
         # Reload the library to apply changes
+        defaults_module = importlib.import_module("controlflow.defaults")
         importlib.reload(controlflow)
+        importlib.reload(defaults_module)
 
     # Check if the warning was logged
     assert any(


### PR DESCRIPTION
This moves default locations from root-level variables to attributes of a `defaults` object which can perform validation. The PR updates docs to match. Note this is a breaking change.

```
controlflow.default_model → controlflow.defaults.model
controlflow.default_agent → controlflow.defaults.agent
controlflow.default_history → controlflow.defaults.history
```