### PR TITLE
Update prompt customization

### DIFF
--- a/docs/tutorial.mdx
+++ b/docs/tutorial.mdx
@@ -423,7 +423,7 @@ with cf.instructions('No more than 5 sentences per document'):
     technical_document.run()
 ```
 
-When you run the `technical_document` task, ControlFlow will assign both the `docs_agent` and the `editor_agent` to complete the task. The `docs_agent` will generate the technical document, and the `editor_agent` will review and edit the document to ensure its accuracy and readability. By default, they will be run in round-robin fashion, but you can customize the agent selection strategy by passing a function as the task's `agent_strategy`.
+When you run the `technical_document` task, ControlFlow will assign both the `docs_agent` and the `editor_agent` to complete the task. The `docs_agent` will generate the technical document, and the `editor_agent` will review and edit the document to ensure its accuracy and readability.
 
 ### Instructions
 

--- a/src/controlflow/flows/flow.py
+++ b/src/controlflow/flows/flow.py
@@ -36,6 +36,11 @@ class Flow(ControlFlowModel):
         description="The default agent for the flow. This agent will be used "
         "for any task that does not specify an agent.",
     )
+    prompt: Optional[str] = Field(
+        None,
+        description="A prompt to display to the agent working on the flow. "
+        "Prompts are formatted as jinja templates, with keywords `flow: Flow` and `context: AgentContext`.",
+    )
     context: dict[str, Any] = {}
     graph: Graph = Field(default_factory=Graph, repr=False, exclude=True)
     _cm_stack: list[contextmanager] = []
@@ -79,6 +84,7 @@ class Flow(ControlFlowModel):
         from controlflow.orchestration import prompt_templates
 
         template = prompt_templates.FlowTemplate(
+            template=self.prompt,
             flow=self,
             context=context,
         )

--- a/src/controlflow/orchestration/prompt_templates.py
+++ b/src/controlflow/orchestration/prompt_templates.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from pydantic import model_validator
 
 from controlflow.agents.agent import Agent
@@ -10,15 +12,14 @@ from controlflow.utilities.types import ControlFlowModel
 
 
 class Template(ControlFlowModel):
-    template: str = None
-    template_path: str = None
+    model_config = dict(extra="allow")
+    template: Optional[str] = None
+    template_path: Optional[str] = None
 
     @model_validator(mode="after")
     def _validate(self):
         if not self.template and not self.template_path:
             raise ValueError("Template or template_path must be provided.")
-        elif self.template and self.template_path:
-            raise ValueError("Only one of template or template_path must be provided.")
         return self
 
     def render(self, **kwargs) -> str:
@@ -29,10 +30,10 @@ class Template(ControlFlowModel):
         del render_kwargs["template"]
         del render_kwargs["template_path"]
 
-        if self.template_path:
-            template = prompt_env.get_template(self.template_path)
-        else:
+        if self.template is not None:
             template = prompt_env.from_string(self.template)
+        else:
+            template = prompt_env.get_template(self.template_path)
         return template.render(**render_kwargs | kwargs)
 
     def should_render(self) -> bool:

--- a/src/controlflow/utilities/testing.py
+++ b/src/controlflow/utilities/testing.py
@@ -1,4 +1,5 @@
 from contextlib import contextmanager
+from functools import partial
 from typing import Union
 
 from langchain_core.language_models.fake_chat_models import FakeMessagesListChatModel
@@ -6,6 +7,9 @@ from langchain_core.language_models.fake_chat_models import FakeMessagesListChat
 import controlflow
 from controlflow.events.history import InMemoryHistory
 from controlflow.llm.messages import AIMessage, BaseMessage
+from controlflow.tasks.task import Task
+
+SimpleTask = partial(Task, objective="test", result_type=None)
 
 
 class FakeLLM(FakeMessagesListChatModel):

--- a/tests/agents/test_agents.py
+++ b/tests/agents/test_agents.py
@@ -1,7 +1,10 @@
 import controlflow
+import pytest
 from controlflow.agents import Agent
 from controlflow.agents.names import AGENTS
+from controlflow.flows import Flow
 from controlflow.instructions import instructions
+from controlflow.orchestration.agent_context import AgentContext
 from controlflow.tasks.task import Task
 from langchain_openai import ChatOpenAI
 
@@ -67,3 +70,28 @@ class TestDefaultAgent:
         task = Task("task")
         assert task.get_agents()[0].model is None
         assert task.get_agents()[0].get_model() is new_model
+
+
+class TestAgentPrompt:
+    @pytest.fixture
+    def agent_context(self) -> AgentContext:
+        return AgentContext(agent=Agent(name="Test Agent"), flow=Flow(), tasks=[])
+
+    def test_default_prompt(self):
+        agent = Agent()
+        assert agent.prompt is None
+
+    def test_default_template(self, agent_context):
+        agent = Agent()
+        prompt = agent.get_prompt(context=agent_context)
+        assert prompt.startswith("# Agent")
+
+    def test_custom_prompt(self, agent_context):
+        agent = Agent(prompt="Custom Prompt")
+        prompt = agent.get_prompt(context=agent_context)
+        assert prompt == "Custom Prompt"
+
+    def test_custom_templated_prompt(self, agent_context):
+        agent = Agent(prompt="{{ agent.name }}", name="abc")
+        prompt = agent.get_prompt(context=agent_context)
+        assert prompt == "abc"

--- a/tests/flows/test_flows.py
+++ b/tests/flows/test_flows.py
@@ -1,6 +1,8 @@
+import pytest
 from controlflow.agents import Agent
 from controlflow.events.events import UserMessage
 from controlflow.flows import Flow, get_flow
+from controlflow.orchestration.agent_context import AgentContext
 from controlflow.tasks.task import Task
 from controlflow.utilities.context import ctx
 
@@ -157,3 +159,28 @@ class TestFlowCreatesDefaults:
         with Flow(agents=[agent]):
             t2 = Task("t2")
             assert t2.get_agents() == [agent]
+
+
+class TestFlowPrompt:
+    @pytest.fixture
+    def agent_context(self) -> AgentContext:
+        return AgentContext(agent=Agent(name="Test Agent"), flow=Flow(), tasks=[])
+
+    def test_default_prompt(self):
+        flow = Flow()
+        assert flow.prompt is None
+
+    def test_default_template(self, agent_context):
+        flow = Flow()
+        prompt = flow.get_prompt(context=agent_context)
+        assert prompt.startswith("# Flow")
+
+    def test_custom_prompt(self, agent_context):
+        flow = Flow(prompt="Custom Prompt")
+        prompt = flow.get_prompt(context=agent_context)
+        assert prompt == "Custom Prompt"
+
+    def test_custom_templated_prompt(self, agent_context):
+        flow = Flow(prompt="{{ flow.name }}", name="abc")
+        prompt = flow.get_prompt(context=agent_context)
+        assert prompt == "abc"


### PR DESCRIPTION
Permits the prompt to be customized for agents/teams/tasks/flows by passing a jinja-templated `prompt` string at init. This allows customization of what details are shared with the agent when compiling each object.