### PR TITLE
Add stable ID for task/agent/team

### DIFF
--- a/src/controlflow/agents/agent.py
+++ b/src/controlflow/agents/agent.py
@@ -62,6 +62,9 @@ class BaseAgent(ControlFlowModel, abc.ABC):
         if self.id is None:
             self.id = self._generate_id()
 
+    def __hash__(self) -> int:
+        return id(self)
+
     def _generate_id(self):
         return hash_objects(
             (type(self).__name__, self.name, self.description, self.prompt)

--- a/src/controlflow/agents/agent.py
+++ b/src/controlflow/agents/agent.py
@@ -1,7 +1,6 @@
 import abc
 import logging
 import random
-import uuid
 from contextlib import contextmanager
 from typing import (
     TYPE_CHECKING,
@@ -27,7 +26,7 @@ from controlflow.tools.tools import (
     handle_tool_call_async,
 )
 from controlflow.utilities.context import ctx
-from controlflow.utilities.types import ControlFlowModel
+from controlflow.utilities.types import ControlFlowModel, hash_objects
 
 from .memory import Memory
 from .names import AGENTS
@@ -45,7 +44,7 @@ class BaseAgent(ControlFlowModel, abc.ABC):
     A base class for agents, which are entities that can complete tasks.
     """
 
-    id: str = Field(default_factory=lambda: str(uuid.uuid4().hex[:5]))
+    id: str = Field(None)
     name: str = Field(
         description="The name of the agent.",
     )
@@ -57,6 +56,16 @@ class BaseAgent(ControlFlowModel, abc.ABC):
         description="A prompt to display as a system message to the agent."
         "Prompts are formatted as jinja templates, with keywords `agent: Agent` and `context: AgentContext`.",
     )
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        if self.id is None:
+            self.id = self._generate_id()
+
+    def _generate_id(self):
+        return hash_objects(
+            (type(self).__name__, self.name, self.description, self.prompt)
+        )
 
     def serialize_for_prompt(self) -> dict:
         return self.model_dump()
@@ -141,6 +150,20 @@ class Agent(BaseAgent):
             ).strip()
 
         super().__init__(**kwargs)
+
+    def _generate_id(self):
+        """
+        Helper function to generate a stable, short, semi-unique ID for the agent.
+        """
+        return hash_objects(
+            (
+                type(self).__name__,
+                self.name,
+                self.description,
+                self.prompt,
+                self.instructions,
+            )
+        )
 
     def serialize_for_prompt(self) -> dict:
         dct = self.model_dump(

--- a/src/controlflow/flows/graph.py
+++ b/src/controlflow/flows/graph.py
@@ -215,7 +215,7 @@ class Graph:
         """
         # Create a cache key based on the input tasks
         cache_key = (
-            f"topo_sort_{tuple(sorted(task.id for task in (tasks or self.tasks)))}"
+            f"topo_sort_{tuple(sorted(id(task) for task in (tasks or self.tasks)))}"
         )
 
         # Check if the result is already in the cache

--- a/src/controlflow/tasks/task.py
+++ b/src/controlflow/tasks/task.py
@@ -215,11 +215,12 @@ class Task(ControlFlowModel):
                 str(self.result_type),
                 self.prompt,
                 self.private,
+                str(self.context),
             )
         )
 
-    def __hash__(self):
-        return hash((self.__class__.__name__, self.id))
+    def __hash__(self) -> int:
+        return id(self)
 
     def __eq__(self, other):
         """

--- a/src/controlflow/tasks/task.py
+++ b/src/controlflow/tasks/task.py
@@ -1,5 +1,4 @@
 import datetime
-import uuid
 from contextlib import ExitStack, contextmanager
 from enum import Enum
 from typing import (
@@ -40,6 +39,7 @@ from controlflow.utilities.tasks import (
 from controlflow.utilities.types import (
     NOTSET,
     ControlFlowModel,
+    hash_objects,
 )
 
 if TYPE_CHECKING:
@@ -68,7 +68,7 @@ COMPLETE_STATUSES = {TaskStatus.SUCCESSFUL, TaskStatus.FAILED, TaskStatus.SKIPPE
 
 
 class Task(ControlFlowModel):
-    id: str = Field(default_factory=lambda: str(uuid.uuid4().hex[:5]))
+    id: str = None
     objective: str = Field(
         ..., description="A brief description of the required result."
     )
@@ -202,6 +202,21 @@ class Task(ControlFlowModel):
         # add task to flow, if exists
         if flow := controlflow.flows.get_flow():
             flow.add_task(self)
+
+        if self.id is None:
+            self.id = self._generate_id()
+
+    def _generate_id(self):
+        return hash_objects(
+            (
+                type(self).__name__,
+                self.objective,
+                self.instructions,
+                str(self.result_type),
+                self.prompt,
+                self.private,
+            )
+        )
 
     def __hash__(self):
         return hash((self.__class__.__name__, self.id))

--- a/src/controlflow/utilities/testing.py
+++ b/src/controlflow/utilities/testing.py
@@ -1,5 +1,4 @@
 from contextlib import contextmanager
-from functools import partial
 from typing import Union
 
 from langchain_core.language_models.fake_chat_models import FakeMessagesListChatModel
@@ -9,7 +8,18 @@ from controlflow.events.history import InMemoryHistory
 from controlflow.llm.messages import AIMessage, BaseMessage
 from controlflow.tasks.task import Task
 
-SimpleTask = partial(Task, objective="test", result_type=None)
+COUNTER = 0
+
+
+def SimpleTask(**kwargs):
+    global COUNTER
+    COUNTER += 1
+
+    kwargs.setdefault("objective", "test")
+    kwargs.setdefault("result_type", None)
+    kwargs.setdefault("context", {})["__counter__"] = str(COUNTER)
+
+    return Task(**kwargs)
 
 
 class FakeLLM(FakeMessagesListChatModel):

--- a/src/controlflow/utilities/types.py
+++ b/src/controlflow/utilities/types.py
@@ -1,3 +1,5 @@
+import hashlib
+import json
 from typing import Optional, Union
 
 import prefect
@@ -5,6 +7,29 @@ from pydantic import BaseModel, ConfigDict
 
 # flag for unset defaults
 NOTSET = "__NOTSET__"
+
+
+def hash_objects(input_data: tuple, len: int = 8) -> str:
+    """
+    Generates a fast, stable MD5 hash for the given tuple of input data.
+
+    Args:
+        input_data (tuple): The tuple of data to hash.
+
+    Returns:
+        str: The hexadecimal digest of the MD5 hash.
+    """
+    # Serialize the tuple into a JSON string
+    serialized_data = json.dumps(input_data, sort_keys=True)
+
+    # Create an MD5 hash object
+    hasher = hashlib.md5()
+
+    # Update the hash object with the serialized string
+    hasher.update(serialized_data.encode("utf-8"))
+
+    # Return the hexadecimal digest of the hash
+    return hasher.hexdigest()[:len]
 
 
 class ControlFlowModel(BaseModel):

--- a/tests/agents/test_agents.py
+++ b/tests/agents/test_agents.py
@@ -36,6 +36,18 @@ class TestAgentInitialization:
 
         assert "test instruction" in agent.instructions
 
+    def test_stable_id(self):
+        agent = Agent(name="Test Agent")
+        assert agent.id == "69dd1abd"
+
+    def test_id_includes_instructions(self):
+        a1 = Agent(name="Test Agent")
+        a2 = Agent(name="Test Agent", instructions="abc")
+        a3 = Agent(name="Test Agent", instructions="def")
+        a4 = Agent(name="Test Agent", instructions="abc", description="xyz")
+
+        assert a1.id != a2.id != a3.id != a4.id
+
 
 class TestDefaultAgent:
     def test_default_agent(self):

--- a/tests/agents/test_teams.py
+++ b/tests/agents/test_teams.py
@@ -12,3 +12,7 @@ def test_team_with_one_agent():
     a1 = Agent(name="a1")
     t = Team(agents=[a1])
     assert t.agents == [a1]
+
+
+def test_stable_id():
+    assert Team(name="Test Team").id == "6a7f9140"

--- a/tests/orchestration/test_agent_context.py
+++ b/tests/orchestration/test_agent_context.py
@@ -55,7 +55,7 @@ class TestAgentContextHandler:
 
 class TestAgentContextAgents:
     def test_add_agents(self, agent_context: AgentContext):
-        agent = Agent()
+        agent = Agent(name="a new test agent")
         assert agent not in agent_context.agents
         agent_context.add_agent(agent)
         assert agent in agent_context.agents

--- a/tests/tasks/test_tasks.py
+++ b/tests/tasks/test_tasks.py
@@ -45,8 +45,8 @@ def test_stable_id():
     t1 = Task(objective="Test Objective")
     t2 = Task(objective="Test Objective")
     t3 = Task(objective="Test Objective+")
-    assert t1.id == t2.id == "d7336030"
-    assert t3.id == "0865d053"
+    assert t1.id == t2.id == "e90eaf1f"
+    assert t3.id == "3cc39696"
 
 
 def test_task_mark_successful_and_mark_failed():

--- a/tests/tasks/test_tasks.py
+++ b/tests/tasks/test_tasks.py
@@ -41,6 +41,14 @@ def test_task_initialization():
     assert task.error is None
 
 
+def test_stable_id():
+    t1 = Task(objective="Test Objective")
+    t2 = Task(objective="Test Objective")
+    t3 = Task(objective="Test Objective+")
+    assert t1.id == t2.id == "d7336030"
+    assert t3.id == "0865d053"
+
+
 def test_task_mark_successful_and_mark_failed():
     task = SimpleTask()
     task.mark_successful(result=None)

--- a/tests/utilities/test_testing.py
+++ b/tests/utilities/test_testing.py
@@ -22,6 +22,7 @@ def test_record_task_events(default_fake_llm):
                 "name": "mark_task_12345_successful",
                 "args": {"result": "Hello!"},
                 "id": "call_ZEPdV8mCgeBe5UHjKzm6e3pe",
+                "type": "tool_call",
             }
         ],
     )
@@ -38,6 +39,7 @@ def test_record_task_events(default_fake_llm):
         "name": "mark_task_12345_successful",
         "args": {"result": "Hello!"},
         "id": "call_ZEPdV8mCgeBe5UHjKzm6e3pe",
+        "type": "tool_call",
     }
     assert events[2].tool_result.model_dump() == dict(
         tool_call_id="call_ZEPdV8mCgeBe5UHjKzm6e3pe",


### PR DESCRIPTION
Presently IDs are truncated UUIDs. This PR makes ID a stable hash of various identifying parameters, such that multiple tasks created in the same flow should share an ID. This is primarily useful for recovering historical events.