### PR TITLE
Add configurable history visibility

### DIFF
--- a/src/controlflow/__init__.py
+++ b/src/controlflow/__init__.py
@@ -1,10 +1,9 @@
 # --- Public top-level API ---
 
-from pyexpat import model
-
 
 from langchain_core.language_models import BaseChatModel
 from .settings import settings
+
 from controlflow.defaults import defaults
 
 from .agents import Agent

--- a/src/controlflow/agents/agent.py
+++ b/src/controlflow/agents/agent.py
@@ -16,6 +16,7 @@ from pydantic import Field, field_serializer
 
 import controlflow
 from controlflow.events.base import Event
+from controlflow.events.history import HistoryVisibility
 from controlflow.instructions import get_instructions
 from controlflow.llm.messages import AIMessage, BaseMessage
 from controlflow.llm.rules import LLMRules
@@ -119,6 +120,13 @@ class Agent(BaseAgent):
         None,
         description="A system template for the agent. The template should be formatted as a jinja2 template.",
     )
+    history_visibility: HistoryVisibility = Field(
+        description="How to determine event visibility when running the flow.",
+        default_factory=lambda: HistoryVisibility(
+            controlflow.settings.default_history_visibility
+        ),
+    )
+
     memory: Optional[Memory] = Field(
         default=None,
         # default_factory=ThreadMemory,
@@ -311,6 +319,3 @@ class Agent(BaseAgent):
             yield ToolCallEvent(agent=self, tool_call=tool_call, message=response)
             result = await handle_tool_call_async(tool_call, tools=tools)
             yield ToolResultEvent(agent=self, tool_call=tool_call, tool_result=result)
-
-
-DEFAULT_AGENT = Agent(name="Marvin")

--- a/src/controlflow/agents/teams.py
+++ b/src/controlflow/agents/teams.py
@@ -88,7 +88,7 @@ class Team(BaseTeam):
 
     def get_agent(self, context: "AgentContext"):
         # if the last event was a tool result, it should be shown to the same agent instead of advancing to the next agent
-        last_agent_event = context.get_events(
+        last_agent_event = context.flow.get_events(
             agents=self.agents,
             tasks=context.tasks,
             types=["tool-result", "agent-message"],

--- a/src/controlflow/defaults.py
+++ b/src/controlflow/defaults.py
@@ -9,7 +9,7 @@ from controlflow.llm.models import BaseChatModel
 from controlflow.utilities.types import ControlFlowModel
 
 from .agents import Agent
-from .events.history import History, HistoryVisibility, InMemoryHistory
+from .events.history import History, InMemoryHistory
 from .llm.models import _get_initial_default_model, model_from_string
 
 __all__ = ["defaults"]
@@ -34,7 +34,6 @@ class Defaults(ControlFlowModel):
     model: Optional[Any]
     history: History
     agent: Agent
-    history_visibility: HistoryVisibility
     # add more defaults here
 
     def __repr__(self) -> str:
@@ -54,5 +53,4 @@ defaults = Defaults(
     model=_default_model,
     history=_default_history,
     agent=_default_agent,
-    history_visibility=controlflow.settings.default_history_visibility,
 )

--- a/src/controlflow/defaults.py
+++ b/src/controlflow/defaults.py
@@ -9,12 +9,16 @@ from controlflow.llm.models import BaseChatModel
 from controlflow.utilities.types import ControlFlowModel
 
 from .agents import Agent
-from .events.history import History, InMemoryHistory
+from .events.history import History, HistoryVisibility, InMemoryHistory
 from .llm.models import _get_initial_default_model, model_from_string
 
 __all__ = ["defaults"]
 
 logger = controlflow.utilities.logging.get_logger(__name__)
+
+_default_model = _get_initial_default_model()
+_default_history = InMemoryHistory()
+_default_agent = Agent(name="Marvin")
 
 
 class Defaults(ControlFlowModel):
@@ -30,6 +34,7 @@ class Defaults(ControlFlowModel):
     model: Optional[Any]
     history: History
     agent: Agent
+    history_visibility: HistoryVisibility
     # add more defaults here
 
     def __repr__(self) -> str:
@@ -46,7 +51,8 @@ class Defaults(ControlFlowModel):
 
 
 defaults = Defaults(
-    model=_get_initial_default_model(),
-    history=InMemoryHistory(),
-    agent=Agent(name="Marvin"),
+    model=_default_model,
+    history=_default_history,
+    agent=_default_agent,
+    history_visibility=controlflow.settings.default_history_visibility,
 )

--- a/src/controlflow/events/base.py
+++ b/src/controlflow/events/base.py
@@ -27,6 +27,7 @@ class Event(ControlFlowModel):
     timestamp: datetime.datetime = Field(
         default_factory=lambda: datetime.datetime.now(datetime.timezone.utc)
     )
+    private_task: bool = False
     persist: bool = True
 
     def to_messages(self, context: "CompileContext") -> list["BaseMessage"]:
@@ -35,6 +36,8 @@ class Event(ControlFlowModel):
     def add_tasks(self, tasks: list["Task"]):
         for task in tasks:
             self.task_ids.add(task.id)
+        if any(task.private for task in tasks):
+            self.private_task = True
 
     def add_agents(self, agents: list["BaseAgent"]):
         from controlflow.agents.teams import Team

--- a/src/controlflow/events/history.py
+++ b/src/controlflow/events/history.py
@@ -10,16 +10,6 @@ from pydantic import Field, TypeAdapter, field_validator
 
 import controlflow
 from controlflow.events.base import Event
-from controlflow.events.events import (
-    AgentMessage,
-    EndTurn,
-    OrchestratorMessage,
-    SelectAgent,
-    TaskCompleteEvent,
-    TaskReadyEvent,
-    ToolResultEvent,
-    UserMessage,
-)
 from controlflow.utilities.types import ControlFlowModel
 
 # This is a global variable that will be shared between all instances of InMemoryStore
@@ -35,6 +25,17 @@ class HistoryVisibility(Enum):
 
 @cache
 def get_event_validator() -> TypeAdapter:
+    from controlflow.events.events import (
+        AgentMessage,
+        EndTurn,
+        OrchestratorMessage,
+        SelectAgent,
+        TaskCompleteEvent,
+        TaskReadyEvent,
+        ToolResultEvent,
+        UserMessage,
+    )
+
     types = Union[
         TaskReadyEvent,
         TaskCompleteEvent,

--- a/src/controlflow/events/history.py
+++ b/src/controlflow/events/history.py
@@ -1,6 +1,7 @@
 import abc
 import json
 import math
+from enum import Enum
 from functools import cache
 from pathlib import Path
 from typing import Optional, Union
@@ -23,6 +24,13 @@ from controlflow.utilities.types import ControlFlowModel
 
 # This is a global variable that will be shared between all instances of InMemoryStore
 IN_MEMORY_STORE = {}
+
+
+class HistoryVisibility(Enum):
+    ALL = "ALL"
+    UPSTREAM = "UPSTREAM"
+    CURRENT_AGENT = "CURRENT_AGENT"
+    CURRENT_TASK = "CURRENT_TASK"
 
 
 @cache
@@ -88,23 +96,19 @@ def filter_events(
 
         # check if the event matches the agent_ids and task_ids
         # if no ids were provided, we assume it *does* match
-        match_agents = True
+
         if (
             agent_ids
             and event.agent_ids
             and not any(a in event.agent_ids for a in agent_ids)
         ):
-            match_agents = False
-        match_tasks = True
+            continue
+
         if (
             task_ids
             and event.task_ids
             and not any(t in event.task_ids for t in task_ids)
         ):
-            match_tasks = False
-
-        # if EITHER match fails, skip this event
-        if not match_agents or not match_tasks:
             continue
 
         new_events.append(event)

--- a/src/controlflow/flows/flow.py
+++ b/src/controlflow/flows/flow.py
@@ -7,7 +7,7 @@ from pydantic import Field
 import controlflow
 from controlflow.agents import Agent
 from controlflow.events.base import Event
-from controlflow.events.history import History
+from controlflow.events.history import History, HistoryVisibility
 from controlflow.flows.graph import Graph
 from controlflow.tasks.task import Task
 from controlflow.utilities.context import ctx
@@ -26,7 +26,14 @@ class Flow(ControlFlowModel):
     thread_id: str = Field(default_factory=lambda: uuid.uuid4().hex)
     name: Optional[str] = None
     description: Optional[str] = None
-    history: History = Field(default_factory=lambda: controlflow.defaults.history)
+    history: History = Field(
+        default_factory=lambda: controlflow.defaults.history,
+        description="An object for storing events that take place during the flow.",
+    )
+    history_visibility: HistoryVisibility = Field(
+        description="How to determine event visibility when running the flow.",
+        default_factory=lambda: controlflow.defaults.history_visibility,
+    )
     tools: list[Callable] = Field(
         default_factory=list,
         description="Tools that will be available to every agent in the flow",

--- a/src/controlflow/flows/flow.py
+++ b/src/controlflow/flows/flow.py
@@ -7,7 +7,7 @@ from pydantic import Field
 import controlflow
 from controlflow.agents import Agent
 from controlflow.events.base import Event
-from controlflow.events.history import History, HistoryVisibility
+from controlflow.events.history import History
 from controlflow.flows.graph import Graph
 from controlflow.tasks.task import Task
 from controlflow.utilities.context import ctx
@@ -29,10 +29,6 @@ class Flow(ControlFlowModel):
     history: History = Field(
         default_factory=lambda: controlflow.defaults.history,
         description="An object for storing events that take place during the flow.",
-    )
-    history_visibility: HistoryVisibility = Field(
-        description="How to determine event visibility when running the flow.",
-        default_factory=lambda: controlflow.defaults.history_visibility,
     )
     tools: list[Callable] = Field(
         default_factory=list,

--- a/src/controlflow/orchestration/agent_context.py
+++ b/src/controlflow/orchestration/agent_context.py
@@ -67,24 +67,23 @@ class AgentContext(ControlFlowModel):
 
     def get_visible_events(
         self,
+        agent: Agent,
         limit: Optional[int] = None,
     ) -> list[Event]:
-        if self.flow.history_visibility == HistoryVisibility.ALL:
+        if agent.history_visibility == HistoryVisibility.ALL:
             agents = None
             tasks = [t for t in self.flow.tasks if not t.private]
-        elif self.flow.history_visibility == HistoryVisibility.UPSTREAM:
+        elif agent.history_visibility == HistoryVisibility.UPSTREAM:
             agents = self.agents
             tasks = [
                 t for t in self.flow.graph.upstream_tasks(self.tasks) if not t.private
             ]
-        elif self.flow.history_visibility == HistoryVisibility.CURRENT_AGENT:
+        elif agent.history_visibility == HistoryVisibility.CURRENT_AGENT:
             agents = self.agents
             tasks = None
-        elif self.flow.history_visibility == HistoryVisibility.CURRENT_TASK:
+        elif agent.history_visibility == HistoryVisibility.CURRENT_TASK:
             agents = None
             tasks = self.tasks
-        else:
-            raise ValueError(f"Invalid history view: {self.flow.history_visibility}")
 
         events = self.flow.get_events(
             agents=agents,
@@ -106,7 +105,7 @@ class AgentContext(ControlFlowModel):
         return "\n\n".join([p for p in prompts if p])
 
     def compile_messages(self, agent: Agent) -> list[BaseMessage]:
-        events = self.get_visible_events()
+        events = self.get_visible_events(agent=agent)
         compiler = MessageCompiler(
             events=events,
             llm_rules=agent.get_llm_rules(),

--- a/src/controlflow/orchestration/agent_context.py
+++ b/src/controlflow/orchestration/agent_context.py
@@ -6,6 +6,7 @@ from pydantic import Field
 
 from controlflow.agents.agent import Agent, BaseAgent
 from controlflow.events.base import Event
+from controlflow.events.history import HistoryVisibility
 from controlflow.events.message_compiler import MessageCompiler
 from controlflow.flows import Flow
 from controlflow.llm.messages import BaseMessage
@@ -64,24 +65,31 @@ class AgentContext(ControlFlowModel):
     def add_instructions(self, instructions: list[str]):
         self.instructions = self.instructions + instructions
 
-    def get_events(
+    def get_visible_events(
         self,
-        agents: list[Agent] = None,
-        tasks: list[Task] = None,
         limit: Optional[int] = None,
-        **kwargs,
     ) -> list[Event]:
-        # if tasks are not provided, include all tasks that are upstream of the current tasks
-        if tasks is None:
+        if self.flow.history_visibility == HistoryVisibility.ALL:
+            agents = None
+            tasks = [t for t in self.flow.tasks if not t.private]
+        elif self.flow.history_visibility == HistoryVisibility.UPSTREAM:
+            agents = self.agents
             tasks = [
                 t for t in self.flow.graph.upstream_tasks(self.tasks) if not t.private
             ]
+        elif self.flow.history_visibility == HistoryVisibility.CURRENT_AGENT:
+            agents = self.agents
+            tasks = None
+        elif self.flow.history_visibility == HistoryVisibility.CURRENT_TASK:
+            agents = None
+            tasks = self.tasks
+        else:
+            raise ValueError(f"Invalid history view: {self.flow.history_visibility}")
 
         events = self.flow.get_events(
-            agents=agents or self.agents,
+            agents=agents,
             tasks=tasks,
             limit=limit or 100,
-            **kwargs,
         )
 
         return events
@@ -98,7 +106,7 @@ class AgentContext(ControlFlowModel):
         return "\n\n".join([p for p in prompts if p])
 
     def compile_messages(self, agent: Agent) -> list[BaseMessage]:
-        events = self.get_events(agents=[agent])
+        events = self.get_visible_events()
         compiler = MessageCompiler(
             events=events,
             llm_rules=agent.get_llm_rules(),

--- a/src/controlflow/orchestration/orchestrator.py
+++ b/src/controlflow/orchestration/orchestrator.py
@@ -150,16 +150,10 @@ class Orchestrator(ControlFlowModel):
                 # if the task is pending, start it
                 if task.is_pending():
                     task.mark_running()
-                    # self.handle_event(
-                    #     ActivateAgent(
-                    #         agent=agent, content=agent.get_activation_prompt()
-                    #     ),
-                    #     agent=agent,
-                    #     tasks=[task],
-                    # )
 
                 task._iteration += 1
                 agent_tasks.append(task)
+
         return agent_tasks
 
     def get_agent(self, task: Task) -> Agent:

--- a/src/controlflow/settings.py
+++ b/src/controlflow/settings.py
@@ -25,12 +25,6 @@ class ControlFlowSettings(BaseSettings):
 
 
 class Settings(ControlFlowSettings):
-    max_task_iterations: Optional[int] = Field(
-        default=100,
-        description="The maximum number of iterations to attempt to run a task"
-        "before raising an error. If None, the system will run indefinitely. ",
-    )
-
     # ------------ home settings ------------
 
     home_path: Path = Field(
@@ -62,6 +56,21 @@ class Settings(ControlFlowSettings):
         default=False,
         description="If False, calling Task.run() outside a flow context will automatically "
         "create a flow and run the task within it. If True, an error will be raised.",
+    )
+
+    # ------------ orchestration settings ------------
+    max_task_iterations: Optional[int] = Field(
+        default=100,
+        description="The maximum number of iterations to attempt to run a task"
+        "before raising an error. If None, the system will run indefinitely. ",
+    )
+
+    default_history_visibility: str = Field(
+        "ALL",
+        description="The default history visibility for flows. "
+        "ALL: all events in the flow are visible. UPSTREAM: only events from "
+        "upstream tasks are visible. CURRENT_AGENT: only events from the "
+        "current agent are visible. CURRENT_TASK: only events from the current task are visible.",
     )
 
     # ------------ LLM settings ------------

--- a/tests/orchestration/test_agent_context.py
+++ b/tests/orchestration/test_agent_context.py
@@ -18,27 +18,27 @@ def agent_context() -> AgentContext:
 class TestAgentContextPersistEvents:
     def test_persist_event(self, agent_context: AgentContext):
         event = UserMessage(content="test")
-        assert not agent_context.get_events()
+        assert not agent_context.get_visible_events()
         agent_context.handle_event(event=event)
-        assert event in agent_context.get_events()
+        assert event in agent_context.get_visible_events()
 
     def test_persist_event_false(self, agent_context: AgentContext):
         event = UserMessage(content="test", persist=False)
-        assert not agent_context.get_events()
+        assert not agent_context.get_visible_events()
         agent_context.handle_event(event=event)
-        assert event not in agent_context.get_events()
+        assert event not in agent_context.get_visible_events()
 
     def test_persist_event_false_kwarg(self, agent_context: AgentContext):
         event = UserMessage(content="test")
-        assert not agent_context.get_events()
+        assert not agent_context.get_visible_events()
         agent_context.handle_event(event=event, persist=False)
-        assert event not in agent_context.get_events()
+        assert event not in agent_context.get_visible_events()
 
     def test_persist_event_false_but_kwarg_true(self, agent_context: AgentContext):
         event = UserMessage(content="test", persist=False)
-        assert not agent_context.get_events()
+        assert not agent_context.get_visible_events()
         agent_context.handle_event(event=event, persist=True)
-        assert event in agent_context.get_events()
+        assert event in agent_context.get_visible_events()
 
 
 class TestAgentContextHandler:
@@ -115,17 +115,17 @@ class TestAgentContextGetEvents:
 
         for t in [t1, t2, t3, t4, t5]:
             context = AgentContext(flow=flow, tasks=[t])
-            events = context.get_events()
+            events = context.get_visible_events()
             assert len(events) == len(flow.graph.upstream_tasks([t]))
 
     def test_get_events_by_agent(self, agents: list[Agent], flow):
         a1, a2 = agents
         context = AgentContext(flow=flow, tasks=[], agents=[a1])
-        events = context.get_events()
+        events = context.get_visible_events()
         assert len(events) == 4
 
         context = AgentContext(flow=flow, tasks=[], agents=[a2])
-        events = context.get_events()
+        events = context.get_visible_events()
         assert len(events) == 2
 
     def test_get_events_by_agent_and_task(self, agents, flow, tasks: list[Task]):
@@ -133,12 +133,12 @@ class TestAgentContextGetEvents:
         [t1, t2, t3, t4, t5] = tasks
 
         context = AgentContext(flow=flow, agents=[a1], tasks=[t1])
-        events = context.get_events()
+        events = context.get_visible_events()
         assert len(events) == 1
 
         context = AgentContext(flow=flow, agents=[a2], tasks=[t1])
-        events = context.get_events()
+        events = context.get_visible_events()
         assert len(events) == 0
 
         context = AgentContext(flow=flow, agents=[a1], tasks=[t2, t4])
-        assert len(context.get_events()) == 3
+        assert len(context.get_visible_events()) == 3

--- a/tests/orchestration/test_agent_context.py
+++ b/tests/orchestration/test_agent_context.py
@@ -17,28 +17,32 @@ def agent_context() -> AgentContext:
 
 class TestAgentContextPersistEvents:
     def test_persist_event(self, agent_context: AgentContext):
+        agent = agent_context.agents[0]
         event = UserMessage(content="test")
-        assert not agent_context.get_visible_events()
+        assert not agent_context.get_visible_events(agent=agent)
         agent_context.handle_event(event=event)
-        assert event in agent_context.get_visible_events()
+        assert event in agent_context.get_visible_events(agent=agent)
 
     def test_persist_event_false(self, agent_context: AgentContext):
+        agent = agent_context.agents[0]
         event = UserMessage(content="test", persist=False)
-        assert not agent_context.get_visible_events()
+        assert not agent_context.get_visible_events(agent=agent)
         agent_context.handle_event(event=event)
-        assert event not in agent_context.get_visible_events()
+        assert event not in agent_context.get_visible_events(agent=agent)
 
     def test_persist_event_false_kwarg(self, agent_context: AgentContext):
+        agent = agent_context.agents[0]
         event = UserMessage(content="test")
-        assert not agent_context.get_visible_events()
+        assert not agent_context.get_visible_events(agent=agent)
         agent_context.handle_event(event=event, persist=False)
-        assert event not in agent_context.get_visible_events()
+        assert event not in agent_context.get_visible_events(agent=agent)
 
     def test_persist_event_false_but_kwarg_true(self, agent_context: AgentContext):
+        agent = agent_context.agents[0]
         event = UserMessage(content="test", persist=False)
-        assert not agent_context.get_visible_events()
+        assert not agent_context.get_visible_events(agent=agent)
         agent_context.handle_event(event=event, persist=True)
-        assert event in agent_context.get_visible_events()
+        assert event in agent_context.get_visible_events(agent=agent)
 
 
 class TestAgentContextHandler:

--- a/tests/orchestration/test_agent_context.py
+++ b/tests/orchestration/test_agent_context.py
@@ -111,71 +111,76 @@ class TestAgentContextGetVisibleEvents:
         flow.add_events(events)
 
     def test_get_events_by_task_ALL(self, agents: list[Agent], flow, tasks: list[Task]):
+        a1, a2 = agents
         t1, t2, t3, t4, t5 = tasks
 
         for t in [t1, t2, t3, t4, t5]:
             context = AgentContext(flow=flow, tasks=[t])
-            events = context.get_visible_events()
+            events = context.get_visible_events(agent=a1)
             assert len(events) == 5
 
     def test_get_events_by_task_UPSTREAM(
         self, agents: list[Agent], flow, tasks: list[Task]
     ):
-        flow.history_visibility = "UPSTREAM"
+        a1, a2 = agents
+        a1.history_visibility = "UPSTREAM"
         t1, t2, t3, t4, t5 = tasks
 
         for t in [t1, t2, t3, t4, t5]:
             context = AgentContext(flow=flow, tasks=[t])
-            events = context.get_visible_events()
+            events = context.get_visible_events(agent=a1)
             assert len(events) == len(flow.graph.upstream_tasks([t]))
 
     def test_get_events_by_task_CURRENT_TASK(
         self, agents: list[Agent], flow, tasks: list[Task]
     ):
-        flow.history_visibility = "CURRENT_TASK"
+        a1, a2 = agents
+        a1.history_visibility = "CURRENT_TASK"
         t1, t2, t3, t4, t5 = tasks
 
         for t in [t1, t2, t3, t4, t5]:
             context = AgentContext(flow=flow, tasks=[t])
-            events = context.get_visible_events()
+            events = context.get_visible_events(agent=a1)
             assert len(events) == 1
 
     def test_get_events_by_task_CURRENT_AGENT(
         self, agents: list[Agent], flow, tasks: list[Task]
     ):
-        flow.history_visibility = "CURRENT_AGENT"
         a1, a2 = agents
+        a2.history_visibility = "CURRENT_AGENT"
         t1, t2, t3, t4, t5 = tasks
 
         for t in [t1, t2, t3, t4, t5]:
             context = AgentContext(flow=flow, tasks=[t], agents=[a2])
-            events = context.get_visible_events()
+            events = context.get_visible_events(agent=a2)
             assert len(events) == 2
 
     def test_get_events_by_agent(self, agents: list[Agent], flow):
-        flow.history_visibility = "UPSTREAM"
-
         a1, a2 = agents
+        a1.history_visibility = "UPSTREAM"
+        a2.history_visibility = "UPSTREAM"
+
         context = AgentContext(flow=flow, tasks=[], agents=[a1])
-        events = context.get_visible_events()
+        events = context.get_visible_events(agent=a1)
         assert len(events) == 4
 
         context = AgentContext(flow=flow, tasks=[], agents=[a2])
-        events = context.get_visible_events()
+        events = context.get_visible_events(agent=a2)
         assert len(events) == 2
 
     def test_get_events_by_agent_and_task(self, agents, flow, tasks: list[Task]):
-        flow.history_visibility = "UPSTREAM"
         a1, a2 = agents
+        a1.history_visibility = "UPSTREAM"
+        a2.history_visibility = "UPSTREAM"
         t1, t2, t3, t4, t5 = tasks
 
         context = AgentContext(flow=flow, agents=[a1], tasks=[t1])
-        events = context.get_visible_events()
+        events = context.get_visible_events(agent=a1)
         assert len(events) == 1
 
         context = AgentContext(flow=flow, agents=[a2], tasks=[t1])
-        events = context.get_visible_events()
+        events = context.get_visible_events(agent=a2)
         assert len(events) == 0
 
         context = AgentContext(flow=flow, agents=[a1], tasks=[t2, t4])
-        assert len(context.get_visible_events()) == 3
+        assert len(context.get_visible_events(agent=a1)) == 3


### PR DESCRIPTION
Agent-level setting that determines how event history is loaded.

- `ALL`: the entire history, across all agents and tasks, is shown
- `UPSTREAM`: only events that EITHER involve the current agent OR are upstream of the current task in the flow DAG are shown
- `CURRENT_AGENT`: only events from the current agent, across all tasks
- `CURRENT_TASK`: only events from the current task, across all agents

```python
a = Agent(history_visibility='UPSTREAM')
```

This will probably require some finessing to get right. In particular, taking a task result, modifying it, then passing that data to another task could interrupt the upstream chain (the downstream task can't detect the upstream) and we'll probably want a way to "load" extra history. 

**Note: ** `ALL` history is the default, which is different than the default on the 0.9 branch so far (but mirrors 0.8 behavior)