### PR TITLE
Handle long tool descriptions

### DIFF
--- a/docs/patterns/tools.mdx
+++ b/docs/patterns/tools.mdx
@@ -70,8 +70,6 @@ def get_weather(
     ...
 ```
 
-
-
 ```python Velocity
 from typing import Annotated
 

--- a/src/controlflow/orchestration/agent_context.py
+++ b/src/controlflow/orchestration/agent_context.py
@@ -94,12 +94,16 @@ class AgentContext(ControlFlowModel):
         return events
 
     def compile_prompt(self, agent: Agent) -> str:
-        from controlflow.orchestration.prompt_templates import InstructionsTemplate
+        from controlflow.orchestration.prompt_templates import (
+            InstructionsTemplate,
+            ToolTemplate,
+        )
 
         prompts = [
             agent.get_prompt(context=self),
             self.flow.get_prompt(context=self),
             *[t.get_prompt(context=self) for t in self.tasks],
+            ToolTemplate(tools=self.tools, context=self).render(),
             InstructionsTemplate(instructions=self.instructions, context=self).render(),
         ]
         return "\n\n".join([p for p in prompts if p])

--- a/src/controlflow/orchestration/agent_context.py
+++ b/src/controlflow/orchestration/agent_context.py
@@ -2,7 +2,7 @@ from contextlib import ExitStack
 from functools import partial, wraps
 from typing import Any, Callable, Optional
 
-from pydantic import Field
+from pydantic import Field, field_validator
 
 from controlflow.agents.agent import Agent, BaseAgent
 from controlflow.events.base import Event
@@ -40,6 +40,12 @@ class AgentContext(ControlFlowModel):
     instructions: list[str] = []
     _context: Optional[ExitStack] = None
 
+    @field_validator("tools", mode="before")
+    def _validate_tools(cls, v):
+        if v:
+            v = as_tools(v)
+        return v
+
     def add_agent(self, agent: BaseAgent):
         self.agents = self.agents + [agent]
 
@@ -60,7 +66,7 @@ class AgentContext(ControlFlowModel):
         self.handlers = self.handlers + handlers
 
     def add_tools(self, tools: list[Tool]):
-        self.tools = self.tools + as_tools(tools)
+        self.tools = self.tools + tools
 
     def add_instructions(self, instructions: list[str]):
         self.instructions = self.instructions + instructions

--- a/src/controlflow/orchestration/prompt_templates.py
+++ b/src/controlflow/orchestration/prompt_templates.py
@@ -7,6 +7,7 @@ from controlflow.agents.teams import Team
 from controlflow.flows import Flow
 from controlflow.orchestration.agent_context import AgentContext
 from controlflow.tasks.task import Task
+from controlflow.tools.tools import Tool
 from controlflow.utilities.general import ControlFlowModel
 from controlflow.utilities.jinja import prompt_env
 
@@ -85,3 +86,12 @@ class InstructionsTemplate(Template):
 
     def should_render(self) -> bool:
         return bool(self.instructions)
+
+
+class ToolTemplate(Template):
+    template_path: str = "tools.md.jinja"
+    tools: list[Tool]
+    context: AgentContext
+
+    def should_render(self) -> bool:
+        return any(t.instructions for t in self.tools)

--- a/src/controlflow/orchestration/prompt_templates/tools.md.jinja
+++ b/src/controlflow/orchestration/prompt_templates/tools.md.jinja
@@ -1,0 +1,10 @@
+# Tools
+
+The following tools have additional instructions:
+
+{% for tool in tools %}
+{% if tool.instructions %}
+## Tool: {{ tool.name }}
+{{ tool.instructions }}
+{% endif %}
+{% endfor %}

--- a/src/controlflow/tools/orchestration.py
+++ b/src/controlflow/tools/orchestration.py
@@ -50,6 +50,7 @@ def create_task_success_tool(task: Task) -> Tool:
         description=f"Mark task {task.id} as successful.",
         private=True,
         end_turn=True,
+        include_return_description=False,
     )
     def succeed(result: result_schema) -> str:  # type: ignore
         task.mark_successful(result=result)
@@ -70,6 +71,7 @@ def create_task_fail_tool(task: Task) -> Tool:
         ),
         private=True,
         end_turn=True,
+        include_return_description=False,
     )
     def fail(reason: str) -> str:
         task.mark_failed(reason=reason)

--- a/src/controlflow/tools/talk_to_user.py
+++ b/src/controlflow/tools/talk_to_user.py
@@ -9,16 +9,25 @@ import controlflow
 from controlflow.tools import tool
 
 INSTRUCTIONS = """
-## Talking to human users
+If a task requires you to interact with a user, it will show
+`user_access=True` and you will be given this tool. You can use it to send
+messages to the user and optionally wait for a response. This is how you
+tell the user things and ask questions. Do not mention your tasks or the
+workflow. The user can only see messages you send them via tool. They can
+not read the rest of the thread. Do not send the user concurrent messages
+that require responses, as this will cause confusion.
 
-If your task requires you to interact with a user, it will show
-`user_access=True` and you will be given a `talk_to_user` tool. You can
-use it to send messages to the user and optionally wait for a response.
-This is how you tell the user things and ask questions. Do not mention
-your tasks or the workflow. The user can only see messages you send
-them via tool. They can not read the rest of the
-thread. 
+You may need to ask the human about multiple tasks at once. Consolidate your
+questions into a single message. For example, if Task 1 requires information
+X and Task 2 needs information Y, send a single message that naturally asks
+for both X and Y.
 
+Human users may give poor, incorrect, or partial responses. You may need to
+ask questions multiple times in order to complete your tasks. Do not make up
+answers for omitted information; ask again and only fail the task if you
+truly can not make progress. If your task requires human interaction and
+neither it nor any assigned agents have `user_access`, you can fail the
+task.
 """
 
 
@@ -54,28 +63,10 @@ async def get_flow_run_input(message: str):
         return response
 
 
-@tool
+@tool(instructions=INSTRUCTIONS, include_return_description=False)
 async def talk_to_user(message: str, wait_for_response: bool = True) -> str:
     """
-    If a task requires you to interact with a user, it will show
-    `user_access=True` and you will be given this tool. You can use it to send
-    messages to the user and optionally wait for a response. This is how you
-    tell the user things and ask questions. Do not mention your tasks or the
-    workflow. The user can only see messages you send them via tool. They can
-    not read the rest of the thread. Do not send the user concurrent messages
-    that require responses, as this will cause confusion.
-
-    You may need to ask the human about multiple tasks at once. Consolidate your
-    questions into a single message. For example, if Task 1 requires information
-    X and Task 2 needs information Y, send a single message that naturally asks
-    for both X and Y.
-
-    Human users may give poor, incorrect, or partial responses. You may need to
-    ask questions multiple times in order to complete your tasks. Do not make up
-    answers for omitted information; ask again and only fail the task if you
-    truly can not make progress. If your task requires human interaction and
-    neither it nor any assigned agents have `user_access`, you can fail the
-    task.
+    Send a message to a human user and optionally wait for a response.
     """
 
     if wait_for_response:

--- a/src/controlflow/tools/tools.py
+++ b/src/controlflow/tools/tools.py
@@ -39,6 +39,12 @@ class Tool(ControlFlowModel):
     description: str = Field(
         description="A description of the tool, which is provided to the LLM"
     )
+    instructions: Optional[str] = Field(
+        None,
+        description="Optional instructions to display to the agent as part of the system prompt"
+        " when this tool is available. Tool descriptions have a 1024 "
+        "character limit, so this is a way to provide extra detail about behavior.",
+    )
     parameters: dict = Field(
         description="The JSON schema for the tool's input parameters"
     )
@@ -106,7 +112,14 @@ class Tool(ControlFlowModel):
 
     @classmethod
     def from_function(
-        cls, fn: Callable, name: str = None, description: str = None, **kwargs
+        cls,
+        fn: Callable,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        instructions: Optional[str] = None,
+        include_param_descriptions: bool = True,
+        include_return_description: bool = True,
+        **kwargs,
     ):
         name = name or fn.__name__
         description = description or fn.__doc__ or ""
@@ -121,39 +134,68 @@ class Tool(ControlFlowModel):
             )
 
         # load parameter descriptions
-        for param in signature.parameters.values():
-            # handle Annotated type hints
-            if typing.get_origin(param.annotation) is Annotated:
-                param_description = " ".join(
-                    str(a) for a in typing.get_args(param.annotation)[1:]
-                )
-            # handle pydantic Field descriptions
-            elif param.default is not inspect.Parameter.empty and isinstance(
-                param.default, pydantic.fields.FieldInfo
-            ):
-                param_description = param.default.description
-            else:
-                param_description = None
+        if include_param_descriptions:
+            for param in signature.parameters.values():
+                # handle Annotated type hints
+                if typing.get_origin(param.annotation) is Annotated:
+                    param_description = " ".join(
+                        str(a) for a in typing.get_args(param.annotation)[1:]
+                    )
+                # handle pydantic Field descriptions
+                elif param.default is not inspect.Parameter.empty and isinstance(
+                    param.default, pydantic.fields.FieldInfo
+                ):
+                    param_description = param.default.description
+                else:
+                    param_description = None
 
-            if param_description:
-                parameters["properties"][param.name]["description"] = param_description
+                if param_description:
+                    parameters["properties"][param.name]["description"] = (
+                        param_description
+                    )
 
         # Handle return type description
-        return_type = signature.return_annotation
-        if return_type is not inspect._empty:
+
+        if (
+            include_return_description
+            and signature.return_annotation is not inspect._empty
+        ):
+            return_schema = {}
             try:
-                return_schema = TypeAdapter(return_type).json_schema()
-                description += f"\n\nReturn value schema: {return_schema}"
+                return_schema.update(
+                    TypeAdapter(signature.return_annotation).json_schema()
+                )
             except PydanticSchemaGenerationError:
                 pass
+            finally:
+                if typing.get_origin(signature.return_annotation) is Annotated:
+                    return_schema["annotation"] = " ".join(
+                        str(a) for a in typing.get_args(signature.return_annotation)[1:]
+                    )
+
+            if return_schema:
+                description += f"\n\nReturn value schema: {return_schema}"
 
         if not description:
             description = "(No description provided)"
+
+        if len(description) > 1024:
+            raise ValueError(
+                inspect.cleandoc(f"""
+                {name}: The tool's description exceeds 1024
+                characters. Please provide a shorter description, fewer
+                annotations, or pass
+                `include_param_descriptions=False` or
+                `include_return_description=False` to `from_function`.
+                """).replace("\n", " ")
+            )
+
         return cls(
             name=name,
             description=description,
             parameters=parameters,
             fn=fn,
+            instructions=instructions,
             **kwargs,
         )
 
@@ -180,11 +222,19 @@ def tool(
     *,
     name: Optional[str] = None,
     description: Optional[str] = None,
+    instructions: Optional[str] = None,
+    include_param_descriptions: bool = True,
+    include_return_description: bool = True,
     **kwargs,
 ) -> Tool:
     """
     Decorator for turning a function into a Tool
     """
+    kwargs.update(
+        instructions=instructions,
+        include_param_descriptions=include_param_descriptions,
+        include_return_description=include_return_description,
+    )
     if fn is None:
         return functools.partial(tool, name=name, description=description, **kwargs)
     return Tool.from_function(fn, name=name, description=description, **kwargs)

--- a/src/controlflow/tools/tools.py
+++ b/src/controlflow/tools/tools.py
@@ -201,10 +201,7 @@ class Tool(ControlFlowModel):
 
     @classmethod
     def from_lc_tool(cls, tool: langchain_core.tools.BaseTool, **kwargs):
-        if isinstance(tool, langchain_core.tools.StructuredTool):
-            fn = tool.func
-        else:
-            fn = lambda *a, **k: None  # noqa
+        fn = tool._run
         return cls(
             name=tool.name,
             description=tool.description,

--- a/tests/orchestration/test_agent_context.py
+++ b/tests/orchestration/test_agent_context.py
@@ -6,6 +6,7 @@ from controlflow.flows import Flow
 from controlflow.orchestration.agent_context import AgentContext
 from controlflow.orchestration.print_handler import PrintHandler
 from controlflow.tasks.task import Task
+from controlflow.tools import tool
 from controlflow.utilities.testing import SimpleTask
 from pydantic import ValidationError
 
@@ -188,3 +189,19 @@ class TestAgentContextGetVisibleEvents:
 
         context = AgentContext(flow=flow, agents=[a1], tasks=[t2, t4])
         assert len(context.get_visible_events(agent=a1)) == 3
+
+
+class TestAgentContextCompilePrompt:
+    def test_instructions_in_prompt(self, agent_context):
+        agent_context.add_instructions(["custom instructions!"])
+        prompt = agent_context.compile_prompt(agent=agent_context.agents[0])
+        assert "custom instructions!" in prompt
+
+    def test_tool_instructions_in_prompt(self, agent_context):
+        @tool(instructions="custom tool instructions!")
+        def f():
+            pass
+
+        agent_context.add_tools([f])
+        prompt = agent_context.compile_prompt(agent=agent_context.agents[0])
+        assert "custom tool instructions!" in prompt

--- a/tests/tools/test_lc_tools.py
+++ b/tests/tools/test_lc_tools.py
@@ -1,13 +1,74 @@
+from unittest.mock import MagicMock
+
 import controlflow
 from langchain_community.tools import DuckDuckGoSearchRun
 
 
-def test_ddg_tool():
+def test_ddg_tool(default_fake_llm, monkeypatch):
+    events = [
+        {
+            "content": "",
+            "additional_kwargs": {
+                "tool_calls": [
+                    {
+                        "index": 0,
+                        "id": "call_zL53FKAth0u3NSglQyW4hSzu",
+                        "function": {
+                            "arguments": '{"query": "top business headlines today"}',
+                            "name": "duckduckgo_search",
+                        },
+                        "type": "function",
+                    },
+                    {
+                        "index": 1,
+                        "id": "call_USrYJBHxxCpqJxUospzHQZfo",
+                        "function": {
+                            "arguments": '{"query": "today\'s top business news"}',
+                            "name": "duckduckgo_search",
+                        },
+                        "type": "function",
+                    },
+                ]
+            },
+            "response_metadata": {
+                "finish_reason": "tool_calls",
+                "model_name": "gpt-4o-2024-05-13",
+                "system_fingerprint": "fp_dd932ca5d1",
+            },
+            "type": "ai",
+            "name": "Marvin",
+            "id": "run-2e65c19b-c631-42f3-a54d-1e4b7298971a",
+            "example": False,
+            "tool_calls": [
+                {
+                    "name": "duckduckgo_search",
+                    "args": {"query": "top business headlines today"},
+                    "id": "call_zL53FKAth0u3NSglQyW4hSzu",
+                    "type": "tool_call",
+                }
+            ],
+            "invalid_tool_calls": [],
+            "usage_metadata": None,
+            "tool_call_chunks": [
+                {
+                    "name": "duckduckgo_search",
+                    "args": '{"query": "top business headlines today"}',
+                    "id": "call_zL53FKAth0u3NSglQyW4hSzu",
+                    "index": 0,
+                    "type": "tool_call_chunk",
+                }
+            ],
+        }
+    ]
+    default_fake_llm.set_responses(events)
+    tool = DuckDuckGoSearchRun()
+    mock_run = MagicMock(return_value=["headline 1", "headline 2"])
+    tool.__dict__.update(dict(_run=mock_run))
     task = controlflow.Task(
         "Retrieve and summarize today's two top business headlines",
-        tools=[DuckDuckGoSearchRun()],
+        tools=[tool],
         # agent=summarizer,
         result_type=list[str],
     )
-    task.run()
-    assert task.is_successful()
+    task.run(steps=1)
+    mock_run.assert_called_once()


### PR DESCRIPTION
OpenAI has started erroring if a tool description exceeds 1024 characters, which the `talk_to_user` tool does. This PR adds functionality to add long tool instructions to the system prompt, and also raises an error if a tool description exceeds the limit.