### PR TITLE
Add support for Annotated result types on tasks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,3 +96,20 @@ skip-magic-trailing-comma = false
 [tool.pytest.ini_options]
 timeout = 120
 asyncio_mode = "auto"
+norecursedirs = [
+    "*.egg-info",
+    ".git",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".vscode",
+    "node_modules",
+]
+testpaths = ["tests"]
+env = [
+    "CONTROLFLOW_TEST_MODE=1",
+    # use 4o-mini for tests by default
+    'D:CONTROLFLOW_LLM_MODEL=openai/gpt-4o-mini',
+    'D:CONTROLFLOW_TOOLS_VERBOSE=1',
+    'D:PREFECT_LOGGING_LEVEL=DEBUG',
+]

--- a/src/controlflow/tasks/task.py
+++ b/src/controlflow/tasks/task.py
@@ -10,6 +10,7 @@ from typing import (
     Optional,
     TypeVar,
     Union,
+    _AnnotatedAlias,
     _LiteralGenericAlias,
 )
 
@@ -99,7 +100,7 @@ class Task(ControlFlowModel):
     )
     status: TaskStatus = TaskStatus.PENDING
     result: Optional[Union[T, str]] = None
-    result_type: Union[type[T], GenericAlias, tuple, None] = Field(
+    result_type: Union[type[T], GenericAlias, _AnnotatedAlias, tuple, None] = Field(
         str,
         description="The expected type of the result. This should be a type"
         ", generic alias, BaseModel subclass, or list of choices. "

--- a/tests/agents/test_agents.py
+++ b/tests/agents/test_agents.py
@@ -16,7 +16,7 @@ class TestAgentInitialization:
         assert agent.get_model() is controlflow.defaults.model
 
     def test_agent_model(self):
-        model = ChatOpenAI(model="gpt-3.5-turbo")
+        model = ChatOpenAI(model="gpt-4o-mini")
         agent = Agent(name="Marvin", model=model)
 
         # None indicates it will be loaded from the default model

--- a/tests/tasks/test_tasks.py
+++ b/tests/tasks/test_tasks.py
@@ -1,4 +1,7 @@
+from typing import Annotated
+
 import pytest
+from pydantic import BaseModel
 
 import controlflow
 from controlflow.agents import Agent
@@ -289,6 +292,23 @@ class TestResultType:
         task = Task("choose 5", result_type=(4, 5, 6))
         with pytest.raises(ValueError):
             task.mark_successful(result=7)
+
+    def test_pydantic_result(self):
+        class Name(BaseModel):
+            first: str
+            last: str
+
+        task = Task("The character said his name is John Doe", result_type=Name)
+        task.run()
+        assert task.result == Name(first="John", last="Doe")
+
+    def test_annotated_result(self):
+        task = Task(
+            "complete the task", result_type=Annotated[str, "a 5 digit zip code"]
+        )
+        task.run()
+        assert len(task.result) == 5
+        assert int(task.result)
 
 
 class TestSuccessTool:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -14,7 +14,8 @@ def test_defaults():
     assert controlflow.settings.tools_raise_on_error is False
     assert controlflow.settings.tools_verbose is True
     # 4o is the default
-    assert controlflow.settings.llm_model == "openai/gpt-4o"
+    assert controlflow.settings.llm_model == "openai/gpt-4o-mini"
+    assert controlflow.settings.prefect_log_level == "DEBUG"
 
 
 def test_temporary_settings():
@@ -26,7 +27,7 @@ def test_temporary_settings():
 
 def test_prefect_settings_apply_at_runtime(caplog):
     prefect_logger = get_logger()
-    assert controlflow.settings.prefect_log_level == "WARNING"
+    controlflow.settings.prefect_log_level = "WARNING"
     prefect_logger.warning("test-log-1")
     controlflow.settings.prefect_log_level = "ERROR"
     prefect_logger.warning("test-log-2")


### PR DESCRIPTION
```python
zip = cf.run('Complete the task', result_type=Annotated[str, 'a 5 digit zip code'])
assert int(zip)
assert len(zip) == 5
```