### PR TITLE
Improve handling of max turns / max turns per call and enforce task.max_turns

### DIFF
--- a/docs/concepts/tasks/running-tasks.mdx
+++ b/docs/concepts/tasks/running-tasks.mdx
@@ -1,0 +1,103 @@
+---
+title: Running Tasks
+---
+
+A task represents an objective for an agent. In order to actually do work, you need to run the task.
+
+The most straightforward way to run a `Task` object is to call its `run()` method:
+
+<CodeGroup>
+```python Code
+import controlflow as cf
+
+task = cf.Task("Write a poem about AI")
+poem = task.run()
+
+print(poem)
+```
+
+```text Result
+In circuits deep and code profound,
+An AI's mind begins to sound.
+Electric thoughts and data streams,
+Crafting worlds and shaping dreams.
+```
+</CodeGroup>
+
+Calling `Task.run()` does a few things behind the scenes:
+1. It creates an `Orchestrator` to coordinate the agentic loop
+2. It provides the orchestrator with details about all of the tasks to run (which could include any dependencies or children of the task invoked) as well as information about how to orchestrate any agents involved.
+3. It starts a loop that continues until the task is complete.
+
+`Task.run()` either returns  the task's result (if the task was successful) or raises an exception (if the task failed). You can also view the result (or the error message) at a later time by accessing the task's `result` property.
+
+
+## Running with `cf.run()`
+
+`cf.run()` is a function that creates and runs a task in a single step. This is functionally equivalent to the example above.
+
+<CodeGroup>
+```python Code
+import controlflow as cf
+
+poem = cf.run("Write a poem about AI")
+```
+
+```text Result
+In circuits deep and code profound,
+An AI's mind begins to sound.
+Electric thoughts and data streams,
+Crafting worlds and shaping dreams.
+```
+</CodeGroup>
+
+## Running with `@task`
+
+The `@task` decorator creates a `Task` object from a function definition and runs it whenever the function is called.
+
+<CodeGroup>
+```python Code
+import controlflow as cf
+
+@cf.task
+def write_poem(topic: str) -> str:
+    """Write a poem about {topic}"""
+
+poem = write_poem("AI")
+
+print(poem)
+```
+```text Result
+In circuits deep and code profound,
+An AI's mind begins to sound.
+Electric thoughts and data streams,
+Crafting worlds and shaping dreams.
+```
+</CodeGroup>
+
+## Controlling task execution
+
+You can control the execution of a task by passing in additional parameters to the `run()` method.
+
+### Limiting LLM calls
+It is possible for agents to get stuck in a loop, invoking the LLM repeatedly without making progress. To prevent this, you can limit the number of LLM calls that an agent can make during its turn, or the total number of turns.
+
+This example sets up a task that might result in an infinite loop, since the agents are prohibited from marking the task complete. However, the `turns` parameter limits the number of turns to 5, and the `calls_per_turn` parameter limits the number of LLM invocations per turn to 1. If you run this code, you should see only 5 actions (either tool calls or messages) before execution ends.
+
+```python 
+import controlflow as cf
+
+task = cf.Task(
+    'Talk amongst yourselves. Do not mark the task as complete.', 
+    agents=[cf.Agent(name='One'), cf.Agent(name='Two'), cf.Agent(name='Three')],
+)
+
+task.run(turns=5, calls_per_turn=1)
+
+assert task.result is None
+assert task.is_running()
+```
+
+<Tip>
+If you're using `cf.run()`, you can pass `turns` and `calls_per_turn` directly to the `run` function.
+</Tip>

--- a/src/controlflow/orchestration/orchestrator.py
+++ b/src/controlflow/orchestration/orchestrator.py
@@ -1,5 +1,5 @@
 import logging
-from typing import TypeVar
+from typing import Optional, TypeVar
 
 from pydantic import Field, field_validator
 
@@ -69,6 +69,7 @@ class Orchestrator(ControlFlowModel):
         Args:
             event (Event): The event to handle.
         """
+        logger.debug(f"Handling event: {event}")
         for handler in self.handlers:
             handler.handle(event)
         if event.persist:
@@ -106,57 +107,78 @@ class Orchestrator(ControlFlowModel):
         tools = as_tools(tools)
         return tools
 
-    def _run_turn(self, max_calls: int = None):
+    def _run_turn(self, max_calls_per_turn: Optional[int] = None):
         """
         Run a single turn of the orchestration process.
 
         Args:
-            max_calls (int, optional): Maximum number of LLM calls to run per turn.
+            calls_per_turn (int, optional): Maximum number of LLM calls to run per turn.
         """
+        if max_calls_per_turn is None:
+            max_calls_per_turn = controlflow.settings.orchestrator_max_calls_per_turn
+
         self.turn_strategy.begin_turn()
 
         for task in self.get_tasks("assigned"):
             task.mark_running()
+            if task._turns >= task.max_turns:
+                task.mark_failed(reason="Max turns exceeded.")
+            else:
+                task._turns += 1
 
         calls = 0
         while not self.turn_strategy.should_end_turn():
-            if max_calls is not None and calls >= max_calls:
+            if max_calls_per_turn is not None and calls >= max_calls_per_turn:
                 break
-            messages = self.compile_messages()
-            tools = self.get_tools()
-            for event in self.agent._run_model(messages=messages, tools=tools):
-                self.handle_event(event)
+            calls += 1
 
             # Check if there are any ready tasks left
             if not self.get_tasks("ready"):
                 break
 
+            messages = self.compile_messages()
+            tools = self.get_tools()
+
+            for event in self.agent._run_model(messages=messages, tools=tools):
+                self.handle_event(event)
+
             # Check if the current agent is still available
             if self.agent not in self.get_available_agents():
                 break
-
-            calls += 1
 
         # at the end of each turn, select the next agent
         if available_agents := self.get_available_agents():
             self.agent = self.turn_strategy.get_next_agent(self.agent, available_agents)
 
-    async def _run_turn_async(self, max_calls: int = None):
+    async def _run_turn_async(self, max_calls_per_turn: Optional[int] = None):
         """
         Run a single turn of the orchestration process asynchronously.
 
         Args:
-            max_calls (int, optional): Maximum number of LLM calls to run per turn.
+            calls_per_turn (int, optional): Maximum number of LLM calls to run per turn.
         """
+        if max_calls_per_turn is None:
+            max_calls_per_turn = controlflow.settings.orchestrator_max_calls_per_turn
+
         self.turn_strategy.begin_turn()
 
         for task in self.get_tasks("assigned"):
             task.mark_running()
+            if task._turns >= task.max_turns:
+                task.mark_failed(reason="Max turns exceeded.")
+            else:
+                task._turns += 1
 
         calls = 0
         while not self.turn_strategy.should_end_turn():
-            if max_calls is not None and calls >= max_calls:
+            if max_calls_per_turn is not None and calls >= max_calls_per_turn:
                 break
+            calls += 1
+
+            # Check if there are any ready tasks left
+            if not self.get_tasks("ready"):
+                break
+
             messages = self.compile_messages()
             tools = self.get_tools()
             async for event in self.agent._run_model_async(
@@ -164,43 +186,42 @@ class Orchestrator(ControlFlowModel):
             ):
                 self.handle_event(event)
 
-            # Check if there are any ready tasks left
-            if not self.get_tasks("ready"):
-                break
-
             # Check if the current agent is still available
             if self.agent not in self.get_available_agents():
                 break
-
-            calls += 1
 
         # at the end of each turn, select the next agent
         if available_agents := self.get_available_agents():
             self.agent = self.turn_strategy.get_next_agent(self.agent, available_agents)
 
-    def run(self, max_turns: int = None, max_calls_per_turn: int = None):
+    def run(
+        self, max_turns: Optional[int] = None, max_calls_per_turn: Optional[int] = None
+    ):
         """
         Run the orchestration process until the session should end.
 
         Args:
-            max_turns (int, optional): Maximum number of turns to run.
-            max_calls_per_turn (int, optional): Maximum number of LLM calls per turn.
+            turns (int, optional): Maximum number of turns to run.
+            calls_per_turn (int, optional): Maximum number of LLM calls per turn.
         """
         import controlflow.events.orchestrator_events
+
+        if max_turns is None:
+            max_turns = controlflow.settings.orchestrator_max_turns
 
         self.handle_event(
             controlflow.events.orchestrator_events.OrchestratorStart(orchestrator=self)
         )
 
-        turns = 0
+        turn = 0
         try:
             while (
                 self.get_tasks("ready") and not self.turn_strategy.should_end_session()
             ):
-                if max_turns is not None and turns >= max_turns:
+                if max_turns is not None and turn >= max_turns:
                     break
-                self._run_turn(max_calls=max_calls_per_turn)
-                turns += 1
+                self._run_turn(max_calls_per_turn=max_calls_per_turn)
+                turn += 1
         except Exception as exc:
             self.handle_event(
                 controlflow.events.orchestrator_events.OrchestratorError(
@@ -215,29 +236,34 @@ class Orchestrator(ControlFlowModel):
                 )
             )
 
-    async def run_async(self, max_turns: int = None, max_calls_per_turn: int = None):
+    async def run_async(
+        self, max_turns: Optional[int] = None, max_calls_per_turn: Optional[int] = None
+    ):
         """
         Run the orchestration process asynchronously until the session should end.
 
         Args:
-            max_turns (int, optional): Maximum number of turns to run.
-            max_calls_per_turn (int, optional): Maximum number of LLM calls per turn.
+            turns (int, optional): Maximum number of turns to run.
+            calls_per_turn (int, optional): Maximum number of LLM calls per turn.
         """
         import controlflow.events.orchestrator_events
+
+        if max_turns is None:
+            max_turns = controlflow.settings.orchestrator_max_turns
 
         self.handle_event(
             controlflow.events.orchestrator_events.OrchestratorStart(orchestrator=self)
         )
 
-        turns = 0
+        turn = 0
         try:
             while (
                 self.get_tasks("ready") and not self.turn_strategy.should_end_session()
             ):
-                if max_turns is not None and turns >= max_turns:
+                if max_turns is not None and turn >= max_turns:
                     break
-                await self._run_turn_async(max_calls=max_calls_per_turn)
-                turns += 1
+                await self._run_turn_async(max_calls_per_turn=max_calls_per_turn)
+                turn += 1
         except Exception as exc:
             self.handle_event(
                 controlflow.events.orchestrator_events.OrchestratorError(

--- a/src/controlflow/settings.py
+++ b/src/controlflow/settings.py
@@ -55,7 +55,7 @@ class Settings(ControlFlowSettings):
 
     # ------------ orchestration settings ------------
     task_max_turns: Optional[int] = Field(
-        default=100,
+        default=None,
         description="The maximum number of agent turns allowed when attempting to run any task. "
         "Turns are counted across the life of the task. If None, tasks may run indefinitely.",
     )

--- a/src/controlflow/settings.py
+++ b/src/controlflow/settings.py
@@ -54,10 +54,20 @@ class Settings(ControlFlowSettings):
     )
 
     # ------------ orchestration settings ------------
-    max_task_iterations: Optional[int] = Field(
+    task_max_turns: Optional[int] = Field(
         default=100,
-        description="The maximum number of iterations to attempt to run a task"
-        "before raising an error. If None, the system will run indefinitely. ",
+        description="The maximum number of agent turns allowed when attempting to run any task. "
+        "Turns are counted across the life of the task. If None, tasks may run indefinitely.",
+    )
+    orchestrator_max_turns: Optional[int] = Field(
+        default=100,
+        description="The maximum number of agent turns allowed when orchestrating tasks. "
+        "Turns are counted within a single orchestrator session. If None, orchestration may run indefinitely.",
+    )
+    orchestrator_max_calls_per_turn: Optional[int] = Field(
+        default=100,
+        description="The maximum number of LLM calls allowed per agent turn when orchestrating tasks. "
+        "If None, orchestration may run indefinitely.",
     )
 
     # ------------ LLM settings ------------

--- a/src/controlflow/tasks/task.py
+++ b/src/controlflow/tasks/task.py
@@ -120,13 +120,13 @@ class Task(ControlFlowModel):
     )
     interactive: bool = False
     created_at: datetime.datetime = Field(default_factory=datetime.datetime.now)
-    max_iterations: Optional[int] = Field(
-        default_factory=lambda: controlflow.settings.max_task_iterations,
-        description="The maximum number of iterations to attempt to run a task.",
+    max_turns: Optional[int] = Field(
+        default_factory=lambda: controlflow.settings.task_max_turns,
+        description="The maximum number of turns to attempt to run a task.",
     )
     _subtasks: set["Task"] = set()
     _downstreams: set["Task"] = set()
-    _iteration: int = 0
+    _turns: int = 0
     _cm_stack: list[contextmanager] = []
     _prefect_task: Optional[PrefectTrackingTask] = None
 

--- a/src/controlflow/utilities/testing.py
+++ b/src/controlflow/utilities/testing.py
@@ -23,7 +23,17 @@ def SimpleTask(**kwargs):
 
 
 class FakeLLM(FakeMessagesListChatModel):
+    def __init__(self, *, responses: list[Union[str, BaseMessage]] = None, **kwargs):
+        super().__init__(responses=[], **kwargs)
+        self.set_responses(responses or ["Hello! This is a response from the FakeLLM."])
+
     def set_responses(self, responses: list[Union[str, BaseMessage]]):
+        if any(not isinstance(m, (str, BaseMessage)) for m in responses):
+            raise ValueError(
+                "Responses must be provided as either a list of strings or AIMessages. "
+                "Each item in the list will be emitted in a cycle when the LLM is called."
+            )
+
         responses = [
             AIMessage(content=m) if isinstance(m, str) else m for m in responses
         ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,12 @@ from .fixtures import *
 
 @pytest.fixture(autouse=True, scope="session")
 def temp_controlflow_settings():
-    with temporary_settings(max_task_iterations=10, enable_experimental_tui=False):
+    with temporary_settings(
+        enable_print_handler=False,
+        task_max_turns=10,
+        orchestrator_max_turns=10,
+        orchestrator_max_calls_per_turn=10,
+    ):
         yield
 
 

--- a/tests/orchestration/test_orchestrator.py
+++ b/tests/orchestration/test_orchestrator.py
@@ -1,0 +1,136 @@
+import pytest
+
+import controlflow
+from controlflow.agents import Agent
+from controlflow.flows import Flow
+from controlflow.orchestration.orchestrator import Orchestrator
+from controlflow.tasks.task import Task
+
+
+@pytest.fixture
+def mocked_orchestrator(monkeypatch):
+    agent = Agent()
+    task = Task("Test task", agents=[agent])
+    flow = Flow()
+    orchestrator = Orchestrator(tasks=[task], flow=flow, agent=agent)
+
+    call_count = 0
+    turn_count = 0
+    original_run_model = Agent._run_model
+    original_run_turn = Orchestrator._run_turn
+
+    def mock_run_model(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        return original_run_model(*args, **kwargs)
+
+    def mock_run_turn(*args, **kwargs):
+        nonlocal turn_count
+        turn_count += 1
+        return original_run_turn(*args, **kwargs)
+
+    monkeypatch.setattr(Agent, "_run_model", mock_run_model)
+    monkeypatch.setattr(Orchestrator, "_run_turn", mock_run_turn)
+
+    return orchestrator, lambda: call_count, lambda: turn_count
+
+
+class TestOrchestratorLimits:
+    def test_default_limits(self, mocked_orchestrator, default_fake_llm, monkeypatch):
+        monkeypatch.setattr(controlflow.defaults, "model", default_fake_llm)
+        orchestrator, get_call_count, get_turn_count = mocked_orchestrator
+
+        orchestrator.run()
+
+        assert get_turn_count() == controlflow.settings.orchestrator_max_turns
+        assert (
+            get_call_count()
+            == controlflow.settings.orchestrator_max_turns
+            * controlflow.settings.orchestrator_max_calls_per_turn
+        )
+
+    @pytest.mark.parametrize(
+        "max_turns, max_calls_per_turn, expected_calls",
+        [
+            (1, 1, 1),
+            (1, 2, 2),
+            (2, 1, 2),
+            (3, 2, 6),
+        ],
+    )
+    def test_custom_limits(
+        self,
+        mocked_orchestrator,
+        default_fake_llm,
+        monkeypatch,
+        max_turns,
+        max_calls_per_turn,
+        expected_calls,
+    ):
+        monkeypatch.setattr(controlflow.defaults, "model", default_fake_llm)
+        orchestrator, get_call_count, _ = mocked_orchestrator
+
+        orchestrator.run(max_turns=max_turns, max_calls_per_turn=max_calls_per_turn)
+
+        assert get_call_count() == expected_calls
+
+    def test_max_turns_reached(
+        self, mocked_orchestrator, default_fake_llm, monkeypatch
+    ):
+        monkeypatch.setattr(controlflow.defaults, "model", default_fake_llm)
+        orchestrator, _, get_turn_count = mocked_orchestrator
+
+        orchestrator.run(max_turns=5)
+
+        assert get_turn_count() == 5
+
+    def test_max_calls_per_turn_reached(
+        self, mocked_orchestrator, default_fake_llm, monkeypatch
+    ):
+        monkeypatch.setattr(controlflow.defaults, "model", default_fake_llm)
+        orchestrator, get_call_count, _ = mocked_orchestrator
+
+        orchestrator.run(max_calls_per_turn=3)
+
+        assert get_call_count() == 3 * controlflow.settings.orchestrator_max_turns
+
+
+def test_run():
+    result = controlflow.run("what's 2 + 2", result_type=int)
+    assert result == 4
+
+
+async def test_run_async():
+    result = await controlflow.run_async("what's 2 + 2", result_type=int)
+    assert result == 4
+
+
+@pytest.mark.parametrize(
+    "max_turns, max_calls_per_turn, expected_calls",
+    [
+        (1, 1, 1),
+        (1, 2, 2),
+        (2, 1, 2),
+        (3, 2, 6),
+    ],
+)
+def test_run_with_limits(
+    monkeypatch, default_fake_llm, max_turns, max_calls_per_turn, expected_calls
+):
+    call_count = 0
+    original_run_model = Agent._run_model
+
+    def mock_run_model(self, *args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        return original_run_model(self, *args, **kwargs)
+
+    monkeypatch.setattr(Agent, "_run_model", mock_run_model)
+
+    controlflow.run(
+        "send messages",
+        max_calls_per_turn=max_calls_per_turn,
+        max_turns=max_turns,
+    )
+
+    assert call_count == expected_calls

--- a/tests/tasks/test_tasks.py
+++ b/tests/tasks/test_tasks.py
@@ -7,6 +7,7 @@ import controlflow
 from controlflow.agents import Agent
 from controlflow.flows import Flow
 from controlflow.instructions import instructions
+from controlflow.orchestration.orchestrator import Orchestrator
 from controlflow.tasks.task import (
     COMPLETE_STATUSES,
     INCOMPLETE_STATUSES,
@@ -14,7 +15,7 @@ from controlflow.tasks.task import (
     TaskStatus,
 )
 from controlflow.utilities.context import ctx
-from controlflow.utilities.testing import SimpleTask
+from controlflow.utilities.testing import FakeLLM, SimpleTask
 
 
 def test_status_coverage():
@@ -412,7 +413,7 @@ class TestSuccessTool:
 
 class TestRun:
     @pytest.mark.parametrize(
-        "max_turns, max_calls_per_turn, expected_calls",
+        "turns, calls_per_turn, expected_calls",
         [
             (1, 1, 1),
             (1, 2, 2),
@@ -424,13 +425,10 @@ class TestRun:
         self,
         monkeypatch,
         default_fake_llm,
-        max_turns,
-        max_calls_per_turn,
+        turns,
+        calls_per_turn,
         expected_calls,
     ):
-        # Tests that the run function correctly limits the number of turns and calls per turn
-        default_fake_llm.set_responses(["hello", "world", "how", "are", "you"])
-
         call_count = 0
         original_run_model = Agent._run_model
 
@@ -443,8 +441,44 @@ class TestRun:
 
         task = Task("send messages")
         task.run(
-            max_calls_per_turn=max_calls_per_turn,
-            max_turns=max_turns,
+            calls_per_turn=calls_per_turn,
+            turns=turns,
         )
 
         assert call_count == expected_calls
+
+
+class TestMaxTurns:
+    def test_default_max_turns(self):
+        task = Task("Test task")
+        assert task.max_turns == controlflow.settings.task_max_turns
+
+    def test_custom_max_turns(self):
+        task = Task("Test task", max_turns=10)
+        assert task.max_turns == 10
+
+    def test_max_turns_reached(self, default_fake_llm: FakeLLM):
+        task = Task("Test task", max_turns=3)
+
+        task.run(calls_per_turn=1)
+        assert task._turns == 3
+        assert task.is_failed()
+        assert task.result == "Max turns exceeded."
+
+    def test_max_turns_only_applies_if_task_is_ready_and_assigned_to_active_agent(
+        self, default_fake_llm
+    ):
+        agent1 = Agent()
+        agent2 = Agent()
+        task1 = Task("Test task 1", max_turns=3, agents=[agent1])
+        task2 = Task("Test task 2", max_turns=3, agents=[agent2])
+
+        Orchestrator(flow=Flow(), tasks=[task1, task2], agent=agent1).run(
+            max_calls_per_turn=1
+        )
+        assert task1._turns == 3
+        assert task1.is_failed()
+        assert task1.result == "Max turns exceeded."
+
+        assert task2._turns == 0
+        assert task2.is_ready()

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -15,7 +15,7 @@ async def test_run_async():
 
 
 @pytest.mark.parametrize(
-    "max_turns, max_calls_per_turn, expected_calls",
+    "turns, calls_per_turn, expected_calls",
     [
         (1, 1, 1),
         (1, 2, 2),
@@ -24,11 +24,8 @@ async def test_run_async():
     ],
 )
 def test_run_with_limits(
-    monkeypatch, default_fake_llm, max_turns, max_calls_per_turn, expected_calls
+    monkeypatch, default_fake_llm, turns, calls_per_turn, expected_calls
 ):
-    # Tests that the run function correctly limits the number of turns and calls per turn
-    default_fake_llm.set_responses(["hello", "world", "how", "are", "you"])
-
     call_count = 0
     original_run_model = Agent._run_model
 
@@ -41,8 +38,8 @@ def test_run_with_limits(
 
     controlflow.run(
         "send messages",
-        max_calls_per_turn=max_calls_per_turn,
-        max_turns=max_turns,
+        max_calls_per_turn=calls_per_turn,
+        max_turns=turns,
     )
 
     assert call_count == expected_calls

--- a/tests/tools/test_lc_tools.py
+++ b/tests/tools/test_lc_tools.py
@@ -43,7 +43,7 @@ def test_lc_base_tool(default_fake_llm, monkeypatch):
         tools=[tool],
         result_type=str,
     )
-    task.run(max_turns=1, max_calls_per_turn=1)
+    task.run(turns=1, calls_per_turn=1)
     mock_run.assert_called_once()
 
 
@@ -69,5 +69,5 @@ def test_ddg_tool(default_fake_llm, monkeypatch):
         tools=[tool],
         result_type=list[str],
     )
-    task.run(max_turns=1, max_calls_per_turn=1)
+    task.run(turns=1, calls_per_turn=1)
     mock_run.assert_called_once()

--- a/tests/tools/test_lc_tools.py
+++ b/tests/tools/test_lc_tools.py
@@ -43,8 +43,8 @@ def test_lc_base_tool(default_fake_llm, monkeypatch):
         tools=[tool],
         result_type=str,
     )
-    task.run(turns=1, calls_per_turn=1)
-    mock_run.assert_called_once()
+    task.run(max_turns=1)
+    mock_run.assert_called()
 
 
 def test_ddg_tool(default_fake_llm, monkeypatch):
@@ -69,5 +69,5 @@ def test_ddg_tool(default_fake_llm, monkeypatch):
         tools=[tool],
         result_type=list[str],
     )
-    task.run(turns=1, calls_per_turn=1)
-    mock_run.assert_called_once()
+    task.run(max_turns=1)
+    mock_run.assert_called()


### PR DESCRIPTION
- task.max_turns can be set to prohibit more than n turns being spent on a task
- orchestrator.max_turns and orchestrator.max_calls_per_turn can be set
- all have configurable defaults