### PR TITLE
Remove unused settings

### DIFF
--- a/src/controlflow/orchestration/orchestrator.py
+++ b/src/controlflow/orchestration/orchestrator.py
@@ -121,7 +121,7 @@ class Orchestrator(ControlFlowModel):
 
         for task in self.get_tasks("assigned"):
             task.mark_running()
-            if task._turns >= task.max_turns:
+            if task.max_turns and task._turns >= task.max_turns:
                 task.mark_failed(reason="Max turns exceeded.")
             else:
                 task._turns += 1
@@ -164,7 +164,7 @@ class Orchestrator(ControlFlowModel):
 
         for task in self.get_tasks("assigned"):
             task.mark_running()
-            if task._turns >= task.max_turns:
+            if task.max_turns and task._turns >= task.max_turns:
                 task.mark_failed(reason="Max turns exceeded.")
             else:
                 task._turns += 1

--- a/src/controlflow/settings.py
+++ b/src/controlflow/settings.py
@@ -40,19 +40,6 @@ class Settings(ControlFlowSettings):
         description="Whether to log workflow prints to the Prefect logger by default.",
     )
 
-    # ------------ flow settings ------------
-
-    eager_mode: bool = Field(
-        default=True,
-        description="If True, @task- and @flow-decorated functions are run immediately. "
-        "This can be set on a per-task or per-flow basis using the `eager` argument.",
-    )
-    strict_flow_context: bool = Field(
-        default=False,
-        description="If False, calling Task.run() outside a flow context will automatically "
-        "create a flow and run the task within it. If True, an error will be raised.",
-    )
-
     # ------------ orchestration settings ------------
     max_task_iterations: Optional[int] = Field(
         default=100,

--- a/src/controlflow/tasks/task.py
+++ b/src/controlflow/tasks/task.py
@@ -344,12 +344,10 @@ class Task(ControlFlowModel):
         """
         Run the task
         """
-        from controlflow.flows import Flow, get_flow
-        from controlflow.orchestration import Orchestrator
 
-        flow = flow or get_flow() or Flow()
+        flow = flow or controlflow.flows.get_flow() or controlflow.flows.Flow()
 
-        orchestrator = Orchestrator(
+        orchestrator = controlflow.orchestration.Orchestrator(
             tasks=[self],
             flow=flow,
             agent=agent or self.get_agents()[0],
@@ -377,12 +375,10 @@ class Task(ControlFlowModel):
         """
         Run the task
         """
-        from controlflow.flows import Flow, get_flow
-        from controlflow.orchestration import Orchestrator
 
-        flow = flow or get_flow() or Flow()
+        flow = flow or controlflow.flows.get_flow() or controlflow.flows.Flow()
 
-        orchestrator = Orchestrator(
+        orchestrator = controlflow.orchestration.Orchestrator(
             tasks=[self],
             flow=flow,
             agent=agent or self.get_agents()[0],

--- a/src/controlflow/tasks/task.py
+++ b/src/controlflow/tasks/task.py
@@ -345,18 +345,9 @@ class Task(ControlFlowModel):
         Run the task
         """
         from controlflow.flows import Flow, get_flow
-
-        flow = flow or get_flow()
-        if flow is None:
-            if controlflow.settings.strict_flow_context:
-                raise ValueError(
-                    "Task.run() must be called within a flow context or with a "
-                    "flow argument if implicit flows are disabled."
-                )
-            else:
-                flow = Flow()
-
         from controlflow.orchestration import Orchestrator
+
+        flow = flow or get_flow() or Flow()
 
         orchestrator = Orchestrator(
             tasks=[self],
@@ -387,18 +378,9 @@ class Task(ControlFlowModel):
         Run the task
         """
         from controlflow.flows import Flow, get_flow
-
-        flow = flow or get_flow()
-        if flow is None:
-            if controlflow.settings.strict_flow_context:
-                raise ValueError(
-                    "Task.run() must be called within a flow context or with a "
-                    "flow argument if implicit flows are disabled."
-                )
-            else:
-                flow = Flow()
-
         from controlflow.orchestration import Orchestrator
+
+        flow = flow or get_flow() or Flow()
 
         orchestrator = Orchestrator(
             tasks=[self],

--- a/tests/tasks/test_tasks.py
+++ b/tests/tasks/test_tasks.py
@@ -9,6 +9,7 @@ from controlflow.flows import Flow
 from controlflow.instructions import instructions
 from controlflow.orchestration import turn_strategies
 from controlflow.orchestration.orchestrator import Orchestrator
+from controlflow.settings import temporary_settings
 from controlflow.tasks.task import (
     COMPLETE_STATUSES,
     INCOMPLETE_STATUSES,
@@ -451,8 +452,9 @@ class TestRun:
 
 class TestMaxTurns:
     def test_default_max_turns(self):
-        task = Task("Test task")
-        assert task.max_turns == controlflow.settings.task_max_turns
+        with temporary_settings(task_max_turns=99):
+            task = Task("Test task")
+            assert task.max_turns == 99
 
     def test_custom_max_turns(self):
         task = Task("Test task", max_turns=10)
@@ -482,6 +484,7 @@ class TestMaxTurns:
             agent=agent1,
             turn_strategy=turn_strategies.Single(),
         ).run(max_calls_per_turn=1)
+
         assert task1._turns == 3
         assert task1.is_failed()
         assert task1.result == "Max turns exceeded."


### PR DESCRIPTION
Eager mode and strict mode are no longer necessary; we create flows on-demand intentionally when using cf.run() and eager mode is essentially always used.