### PR TITLE
Remove max turns from task

### DIFF
--- a/src/controlflow/orchestration/orchestrator.py
+++ b/src/controlflow/orchestration/orchestrator.py
@@ -121,10 +121,6 @@ class Orchestrator(ControlFlowModel):
 
         for task in self.get_tasks("assigned"):
             task.mark_running()
-            if task.max_turns and task._turns >= task.max_turns:
-                task.mark_failed(reason="Max turns exceeded.")
-            else:
-                task._turns += 1
 
         calls = 0
         while not self.turn_strategy.should_end_turn():
@@ -164,10 +160,6 @@ class Orchestrator(ControlFlowModel):
 
         for task in self.get_tasks("assigned"):
             task.mark_running()
-            if task.max_turns and task._turns >= task.max_turns:
-                task.mark_failed(reason="Max turns exceeded.")
-            else:
-                task._turns += 1
 
         calls = 0
         while not self.turn_strategy.should_end_turn():

--- a/src/controlflow/settings.py
+++ b/src/controlflow/settings.py
@@ -41,11 +41,6 @@ class Settings(ControlFlowSettings):
     )
 
     # ------------ orchestration settings ------------
-    task_max_turns: Optional[int] = Field(
-        default=None,
-        description="The maximum number of agent turns allowed when attempting to run any task. "
-        "Turns are counted across the life of the task. If None, tasks may run indefinitely.",
-    )
     orchestrator_max_turns: Optional[int] = Field(
         default=100,
         description="The maximum number of agent turns allowed when orchestrating tasks. "

--- a/src/controlflow/tasks/task.py
+++ b/src/controlflow/tasks/task.py
@@ -119,13 +119,8 @@ class Task(ControlFlowModel):
     )
     interactive: bool = False
     created_at: datetime.datetime = Field(default_factory=datetime.datetime.now)
-    max_turns: Optional[int] = Field(
-        default_factory=lambda: controlflow.settings.task_max_turns,
-        description="The maximum number of turns to attempt to run a task.",
-    )
     _subtasks: set["Task"] = set()
     _downstreams: set["Task"] = set()
-    _turns: int = 0
     _cm_stack: list[contextmanager] = []
 
     model_config = dict(extra="forbid", arbitrary_types_allowed=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,6 @@ from .fixtures import *
 def temp_controlflow_settings():
     with temporary_settings(
         enable_print_handler=False,
-        task_max_turns=10,
         orchestrator_max_turns=10,
         orchestrator_max_calls_per_turn=10,
     ):


### PR DESCRIPTION
It's very appealing to limit the number of turns for attempting a task by setting `Task(max_turns=...)` but unfortunately in practice this isn't straightforward. If a single agent is applied to the task, then it can iterate forever because there is no concept of formally "ending" a turn. On the other hand, we can't use LLM invocations because a turn *usually* requires two invocations - one to use a tool and another to process it. For the moment, enforcing operational limits at the Task level is too complex. We will leave `run()` limits in place.