### PR TITLE
Make flow context explicit

### DIFF
--- a/docs/concepts/flows.mdx
+++ b/docs/concepts/flows.mdx
@@ -119,19 +119,18 @@ The following flow properties are inferred from the decorated function:
 | ------------- | ------------- |
 | `name` | The function's name |
 | `description` | The function's docstring |
-| `context` | The function's arguments (keyed by argument name) |
+| `context` | The function's arguments, if specified as `context_kwargs` (keyed by argument name) |
 
-Additional properties can be set by passing keyword arguments directly to the `@flow` decorator or to the `flow_kwargs` parameter when calling the decorated function.
-
-<Tip>
-You may not want the arguments to your flow function to be used as context. In that case, you can set `args_as_context=False` when decorating or calling the function:
+To automatically put some of your flow's arguments into the global context that all agents can see, specify `context_kwargs` when decorating your flow:
 
 ```python
-@cf.flow(args_as_context=False)
-def my_flow(secret_var: str):
+@cf.flow(context_kwargs=["x"])
+def my_flow(x: int, y: int):
+    # x will be automatically added to a global, agent-visible context
     ...
 ```
-</Tip>
+
+Additional properties can be set by passing keyword arguments directly to the `@flow` decorator or to the `flow_kwargs` parameter when calling the decorated function.
 
 ### The `Flow` object and context manager
 

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -103,6 +103,33 @@ class TestFlowDecorator:
         result = partial_flow()
         assert result == 10
 
+    def test_flow_decorator_with_context_kwargs(self):
+        @controlflow.flow(context_kwargs=["x", "z"])
+        def flow_with_context(x: int, y: int, z: str):
+            flow = controlflow.flows.get_flow()
+            return flow.context
+
+        result = flow_with_context(1, 2, "test")
+        assert result == {"x": 1, "z": "test"}
+
+    def test_flow_decorator_without_context_kwargs(self):
+        @controlflow.flow
+        def flow_without_context(x: int, y: int, z: str):
+            flow = controlflow.flows.get_flow()
+            return flow.context
+
+        result = flow_without_context(1, 2, "test")
+        assert result == {}
+
+    async def test_async_flow_decorator_with_context_kwargs(self):
+        @controlflow.flow(context_kwargs=["a", "b"])
+        async def async_flow_with_context(a: int, b: str, c: float):
+            flow = controlflow.flows.get_flow()
+            return flow.context
+
+        result = await async_flow_with_context(10, "hello", 3.14)
+        assert result == {"a": 10, "b": "hello"}
+
 
 class TestTaskDecorator:
     def test_task_decorator_sync_as_task(self):


### PR DESCRIPTION
Rather than automatically putting all flow args in context, users can now opt-in to this behavior:

```python
import controlflow as cf

@cf.flow(context_kwargs=['x'])
def f(x, y):
    # x will be in a global context visible to all agents
```

Closes #341 