### PR TITLE
Orchestrator: exclude `handlers` field from being serialized

### DIFF
--- a/src/controlflow/orchestration/orchestrator.py
+++ b/src/controlflow/orchestration/orchestrator.py
@@ -51,7 +51,7 @@ class Orchestrator(ControlFlowModel):
         description="The strategy to use for managing agent turns",
         validate_default=True,
     )
-    handlers: list[Union[Handler, AsyncHandler]] = Field(None, validate_default=True)
+    handlers: list[Union[Handler, AsyncHandler]] = Field(None, validate_default=True, exclude=True)
 
     @field_validator("turn_strategy", mode="before")
     def _validate_turn_strategy(cls, v):

--- a/src/controlflow/orchestration/orchestrator.py
+++ b/src/controlflow/orchestration/orchestrator.py
@@ -51,7 +51,9 @@ class Orchestrator(ControlFlowModel):
         description="The strategy to use for managing agent turns",
         validate_default=True,
     )
-    handlers: list[Union[Handler, AsyncHandler]] = Field(None, validate_default=True, exclude=True)
+    handlers: list[Union[Handler, AsyncHandler]] = Field(
+        None, validate_default=True, exclude=True
+    )
 
     @field_validator("turn_strategy", mode="before")
     def _validate_turn_strategy(cls, v):


### PR DESCRIPTION
Attempting to serialize an `Event` entity within a custom `Handler` / `AsyncHandler` would raise an error on `.json()` due to the handler not being serializable - which makes sense, as it is not a pydantic model. 
A handler usually points to a callable python object (or a collection of them) which do not belong  into a serialization context