### PR TITLE
fix(orchestrator): OrchestratorError to serialize `Exception` as `str`

### DIFF
--- a/src/controlflow/events/orchestrator_events.py
+++ b/src/controlflow/events/orchestrator_events.py
@@ -1,4 +1,7 @@
-from typing import Literal
+from dataclasses import Field
+from typing import Annotated, Literal
+
+from pydantic.functional_serializers import PlainSerializer
 
 from controlflow.agents.agent import Agent
 from controlflow.events.base import UnpersistedEvent
@@ -21,7 +24,7 @@ class OrchestratorError(UnpersistedEvent):
     event: Literal["orchestrator-error"] = "orchestrator-error"
     persist: bool = False
     orchestrator: Orchestrator
-    error: Exception
+    error: Annotated[Exception, PlainSerializer(lambda x: str(x), return_type=str)]
 
 
 class AgentTurnStart(UnpersistedEvent):


### PR DESCRIPTION
Issue occurs when attempting to `model_dump_json()` or `json()` with `OrchestratorError.error is Exception` 