### PR TITLE
Remove model typing due to validation error

### DIFF
--- a/src/controlflow/llm/rules.py
+++ b/src/controlflow/llm/rules.py
@@ -1,8 +1,9 @@
 import textwrap
-from typing import Optional
+from typing import Any, Optional, Union
 
 from langchain_anthropic import ChatAnthropic
 from langchain_openai import AzureChatOpenAI, ChatOpenAI
+from pydantic import Field
 
 from controlflow.llm.models import BaseChatModel
 from controlflow.utilities.general import ControlFlowModel, unwrap
@@ -17,7 +18,7 @@ class LLMRules(ControlFlowModel):
     necessary.
     """
 
-    model: Optional[BaseChatModel]
+    model: Any
 
     # require at least one non-system message
     require_at_least_one_message: bool = False
@@ -54,7 +55,7 @@ class LLMRules(ControlFlowModel):
 class OpenAIRules(LLMRules):
     require_message_name_format: str = r"[^a-zA-Z0-9_-]"
 
-    model: ChatOpenAI
+    model: Any
 
     def model_instructions(self) -> list[str]:
         instructions = []


### PR DESCRIPTION
An issue was raised in Slack that `AzureChatOpenAI` models were failing with a validation error when being added to an LLMRules object. At first I thought this was a simple fix, as the `OpenAIRules` typed its `model` field as `ChatOpenAI`, not `Union[ChatOpenAI, AzureChatOpenAI]`. However, an error is still being raised even after that change which appears to persist in a simple MRE. 

We can resolve it in CF by removing typing on this field (which isn't great, but fine for now). I will open an issue in Pydantic with the MRE to learn more.