### PR TITLE
Bump openai version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,7 @@ dependencies = [
     "langchain_openai>=0.2",
     "langchain-anthropic>=0.2",
     "markdownify>=0.12.1",
-    "openai<1.47",
-    # 1.47.0 introduced a bug with attempting to reuse an async client that doesnt have an obvious solution
+    "openai>=1.55.3",
     "pydantic-settings>=2.2.1",
     "textual>=0.61.1",
     "tiktoken>=0.7.0",


### PR DESCRIPTION
A bug was introduced in the openai client which affects all CF installs. We had pinned openai under 1.47 to avoid a previous bug, but that's resolved so we can update the pin here. (Not sure why that pin didn't protect from this bug tbh, maybe the version was getting bumped elsewhere silently?)

The bug manifests as: `Client.__init__() got an unexpected keyword argument 'proxies'`

https://github.com/openai/openai-python/issues/1903